### PR TITLE
feat(listing-gtm): Coinstore listing GTM launch stack (landing, supporter opt-in, proof board)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -144,7 +144,10 @@ src/
 - Include a clear description of what changed and why
 - Reference the issue number (e.g., "Closes #5")
 - Update `CLAUDE.md` if you change architecture or add new services
+- Update relevant documentation if behavior changes
 - Add tests for new functionality
+- Use the repo PR template (`.github/pull_request_template.md`) and complete the `pr_context` block for fast human/agent handoff
+- Assign explicit `owner`, `approver`, and `publisher` in the PR body before requesting final review
 
 ## Questions?
 

--- a/.github/pr-context.schema.json
+++ b/.github/pr-context.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Pull Request Context",
+  "description": "Machine-readable context embedded in PR body under `pr_context`.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "change_type",
+    "scope",
+    "release_blocking",
+    "risk_level",
+    "breaking_change",
+    "db_migration",
+    "requires_follow_up",
+    "owner",
+    "approver",
+    "publisher"
+  ],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "change_type": {
+      "type": "string",
+      "enum": ["feat", "fix", "docs", "refactor", "test", "chore"]
+    },
+    "scope": {
+      "type": "string",
+      "minLength": 1
+    },
+    "linked_issue": {
+      "type": "string"
+    },
+    "release_blocking": {
+      "type": "boolean"
+    },
+    "risk_level": {
+      "type": "string",
+      "enum": ["low", "medium", "high"]
+    },
+    "breaking_change": {
+      "type": "boolean"
+    },
+    "db_migration": {
+      "type": "boolean"
+    },
+    "requires_follow_up": {
+      "type": "boolean"
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "approver": {
+      "type": "string",
+      "minLength": 1
+    },
+    "publisher": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+## PR Context (for humans + agents)
+
+```yaml
+pr_context:
+  version: 1
+  change_type: feat # feat|fix|docs|refactor|test|chore
+  scope: "" # short scope, e.g. listing-gtm/proof-page
+  linked_issue: "" # optional issue/ticket URL or ID
+  release_blocking: false
+  risk_level: low # low|medium|high
+  breaking_change: false
+  db_migration: false
+  requires_follow_up: false
+  owner: "" # DRI for this PR
+  approver: "" # final signoff owner
+  publisher: "" # who deploys/ships
+```
+
+## Summary
+- What changed?
+- Why now?
+
+## Change Set
+- Main files/areas touched:
+- User-visible behavior changes:
+- Non-goals (what this PR does not do):
+
+## Test Plan
+- Commands run:
+- Results:
+- Manual checks (if any):
+
+## Risk and Rollback
+- Main risks:
+- Rollback or mitigation plan:
+
+## Handoff Notes
+- Open follow-ups:
+- Decisions needed:
+- Deployment/publish steps:
+
+## Checklist
+- [ ] Scope is focused and reviewable.
+- [ ] Docs updated (if behavior changed).
+- [ ] Tests added/updated where appropriate.
+- [ ] No secrets or sensitive data included.
+- [ ] Owner/Approver/Publisher set in `pr_context`.

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,0 +1,47 @@
+name: PR Template Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate-pr-body:
+    name: Validate PR Body Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required PR template sections
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request?.body || "";
+
+            const requiredTokens = [
+              "pr_context:",
+              "change_type:",
+              "scope:",
+              "release_blocking:",
+              "risk_level:",
+              "breaking_change:",
+              "db_migration:",
+              "requires_follow_up:",
+              "owner:",
+              "approver:",
+              "publisher:",
+              "## Summary",
+              "## Change Set",
+              "## Test Plan",
+              "## Risk and Rollback",
+              "## Handoff Notes",
+              "## Checklist"
+            ];
+
+            const missing = requiredTokens.filter((token) => !body.includes(token));
+
+            if (missing.length > 0) {
+              core.setFailed(
+                "PR body is missing required template content: " + missing.join(", ")
+              );
+              return;
+            }
+
+            core.notice("PR template sections detected.");

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .vscode/
 .idea/
 data/
+docs/listing-gtm/release/

--- a/docs/listing-gtm/PR_DRAFT_COINSTORE_GTM.md
+++ b/docs/listing-gtm/PR_DRAFT_COINSTORE_GTM.md
@@ -1,0 +1,86 @@
+# Proposed PR Title
+
+`feat(listing-gtm): Coinstore listing GTM launch stack (landing, supporter opt-in, proof board)`
+
+# PR Body Draft
+
+## PR Context (for humans + agents)
+
+```yaml
+pr_context:
+  version: 1
+  change_type: feat
+  scope: listing-gtm/coinstore-launch
+  linked_issue: ""
+  release_blocking: true
+  risk_level: medium
+  breaking_change: false
+  db_migration: false
+  requires_follow_up: true
+  owner: TEMP_RELEASE_OWNER
+  approver: TEMP_RELEASE_OWNER
+  publisher: TEMP_RELEASE_OWNER
+```
+
+## Summary
+- Adds a 3-page launch web stack for Coinstore listing GTM.
+- Introduces supporter opt-in flow that links token and non-token participation to AI prompt cadence and local ecosystem stewardship context.
+- Adds proof board flow for retirement/certificate evidence and local proof ops handling.
+
+## Change Set
+- Main files/areas touched:
+  - `docs/listing-gtm/web/listing-landing.html`
+  - `docs/listing-gtm/web/supporter-opt-in.html`
+  - `docs/listing-gtm/web/proof-page.html`
+  - `docs/listing-gtm/web/proof-feed.json`
+  - `docs/listing-gtm/web/assets/regen-campaign.css`
+  - `docs/listing-gtm/web/assets/regen-campaign.js`
+  - `docs/listing-gtm/templates/*` (Telegram + ops templates)
+  - `docs/listing-gtm/scripts/apply-live-urls.mjs`
+- User-visible behavior changes:
+  - Supporter opt-in profile now supports holder, non-holder, and hybrid modes.
+  - Opt-in profile captures long-term commitment and stewardship context.
+  - Proof board now supports feed-based metrics and local proof submission cache.
+  - Telegram templates now align to `buy -> opt in -> prove`.
+- Non-goals:
+  - No backend API integration yet.
+  - No exchange automation integration in this PR.
+
+## Test Plan
+- Commands run:
+  - `node --check docs/listing-gtm/web/assets/regen-campaign.js`
+- Results:
+  - JS syntax check passes.
+- Manual checks:
+  - [ ] Open each page and validate navigation flow.
+  - [ ] Submit supporter profile and confirm local snapshot.
+  - [ ] Submit local proof and copy `#proof` block.
+  - [ ] Verify proof board reads `proof-feed.json`.
+
+## Risk and Rollback
+- Main risks:
+  - Static pages can drift from live campaign rules if not updated.
+  - Local storage cache is browser-local and not shared.
+- Rollback or mitigation:
+  - Revert to previous static prototype pages.
+  - Keep proof feed updates disciplined via ops log.
+
+## Handoff Notes
+- Open follow-ups:
+  - Replace placeholder URLs once publishing endpoints are confirmed.
+  - Assign permanent owner/approver/publisher after fastlane period.
+- Decisions needed:
+  - Final hosting destination for web pages.
+  - Final rules URL (currently `supporter-opt-in.html#campaign-rules`).
+- Deployment/publish steps:
+  1. Publish `/docs/listing-gtm/web` directory preserving relative paths.
+  2. Run URL replacement script:
+     `node docs/listing-gtm/scripts/apply-live-urls.mjs --landing <...> --proof <...> --rules <...>`
+  3. Post pinned message + Day 1 Telegram update.
+
+## Checklist
+- [ ] Scope is focused and reviewable.
+- [ ] Docs updated (if behavior changed).
+- [ ] Tests added/updated where appropriate.
+- [ ] No secrets or sensitive data included.
+- [ ] Owner/Approver/Publisher set in `pr_context`.

--- a/docs/listing-gtm/README.md
+++ b/docs/listing-gtm/README.md
@@ -1,0 +1,73 @@
+# Listing GTM Units
+
+This folder tracks execution units for imminent exchange listing GTM.
+
+## Unit Docs
+1. `unit-2-listing-landing-page.md`
+2. `unit-3-proof-page.md`
+3. `unit-4-campaign-buy-participate-proof.md`
+4. `unit-5-telegram-ops-kit.md`
+5. `unit-6-exchange-mm-runbook.md`
+6. `unit-7-kpi-dashboard-spec.md`
+7. `fastlane-single-owner.md`
+8. `PR_DRAFT_COINSTORE_GTM.md`
+9. `TECH_SIGNOFF_PACKET.md`
+10. `VALIDATOR_REQUEST_MESSAGE.md`
+11. `WAIT_STATE_CHECKLIST.md`
+12. `unit-8-staging-publish.md`
+13. `unit-9-url-hydration-and-strict-preflight.md`
+14. `unit-10-ten-minute-technical-signoff.md`
+15. `unit-11-pr-cut-and-review-routing.md`
+16. `unit-12-listing-day-rehearsal.md`
+17. `unit-13-day-0-content-queue.md`
+
+## Web Build (3 Pages)
+1. `web/listing-landing.html`
+2. `web/supporter-opt-in.html`
+3. `web/proof-page.html`
+4. `web/proof-feed.json` (proof board data source)
+5. `web/assets/regen-campaign.css`
+6. `web/assets/regen-campaign.js`
+
+Brand mode:
+1. Default `regen`
+2. Alternate `bridge`/`bridge.eco` via query param `?brand=bridge`
+
+## Templates
+1. `templates/telegram-pinned-message.txt`
+2. `templates/telegram-daily-update.md`
+3. `templates/telegram-mod-quick-replies.md`
+4. `templates/telegram-link-values.md`
+5. `templates/telegram-14-day-posting-pack.md`
+6. `templates/listing-day-ops-log.md`
+7. `templates/kpi-weekly.csv`
+8. `templates/kpi-dashboard-metrics.json`
+
+## Scripts
+1. `scripts/apply-live-urls.mjs`
+2. `scripts/preflight-check.mjs`
+3. `scripts/create-release-bundle.mjs`
+4. `scripts/update-proof-feed.mjs`
+
+## Immediate Use
+1. Assign DRI/Approver/Publisher in each unit doc.
+2. Replace placeholder links and owner fields.
+3. Publish 3-page stack in this order: `listing-landing.html` -> `supporter-opt-in.html` -> `proof-page.html`.
+4. Activate Telegram ops cadence and listing-day ops log.
+5. Start KPI baseline capture on day 0.
+6. Use `PR_DRAFT_COINSTORE_GTM.md` for the Coinstore GTM PR title/body.
+7. Use `TECH_SIGNOFF_PACKET.md` for fast technical signoff.
+8. Send `VALIDATOR_REQUEST_MESSAGE.md` to technical validator.
+9. Pause using `WAIT_STATE_CHECKLIST.md` until validator/URL trigger.
+
+## Commands
+1. Preflight (allows unresolved URL placeholders):
+   `npm run gtm:preflight`
+2. Preflight strict (fails if URL placeholders are still unresolved):
+   `npm run gtm:preflight:strict`
+3. Apply live URLs:
+   `node docs/listing-gtm/scripts/apply-live-urls.mjs --landing <...> --proof <...> --rules <...>`
+4. Update proof feed after each verified event:
+   `node docs/listing-gtm/scripts/update-proof-feed.mjs --retirement-id <...> --tx-hash <...> --certificate-url <...> --credits <...> --notes "<...>"`
+5. Create release bundle for publisher handoff:
+   `npm run gtm:bundle`

--- a/docs/listing-gtm/TECH_SIGNOFF_PACKET.md
+++ b/docs/listing-gtm/TECH_SIGNOFF_PACKET.md
@@ -1,0 +1,58 @@
+# Coinstore GTM Technical Signoff Packet (10-Minute Review)
+
+## Goal
+Enable one technical owner to approve and ship with minimal back-and-forth.
+
+## What Is Included
+1. 3-page static launch flow:
+   - `web/listing-landing.html`
+   - `web/supporter-opt-in.html`
+   - `web/proof-page.html`
+2. Shared assets:
+   - `web/assets/regen-campaign.css`
+   - `web/assets/regen-campaign.js`
+3. Proof data source:
+   - `web/proof-feed.json`
+4. Ops templates and scripts for URL patching, proof updates, and preflight checks.
+
+## Key Product Guarantee
+Anyone can opt in to align AI prompting with regeneration:
+1. Holder mode
+2. Non-holder supporter mode
+3. Hybrid mode
+
+## 10-Minute Reviewer Path
+1. Open all 3 pages and confirm nav works between them.
+2. Confirm brand mode toggles:
+   - append `?brand=regen`
+   - append `?brand=bridge`
+3. On supporter page:
+   - submit one holder profile
+   - submit one non-holder profile
+   - verify `#supporter-optin` copy block
+4. On proof page:
+   - submit a local proof entry
+   - verify `#proof` copy block
+   - confirm `proof-feed.json` entries render
+5. Run checks:
+   - `npm run gtm:preflight`
+   - `node --check docs/listing-gtm/web/assets/regen-campaign.js`
+
+## Launch-Time Commands
+1. Apply live URLs:
+   `node docs/listing-gtm/scripts/apply-live-urls.mjs --landing <...> --proof <...> --rules <...>`
+2. Strict preflight:
+   `npm run gtm:preflight:strict`
+3. Create handoff bundle:
+   `npm run gtm:bundle`
+
+## PR Metadata
+Use:
+- `PR_DRAFT_COINSTORE_GTM.md` for title/body.
+- Title:
+  `feat(listing-gtm): Coinstore listing GTM launch stack (landing, supporter opt-in, proof board)`
+
+## Known Limits
+1. Static front-end only; no backend persistence.
+2. Local storage is browser-local for quick ops.
+3. Live URLs still required for final template token replacement.

--- a/docs/listing-gtm/VALIDATOR_REQUEST_MESSAGE.md
+++ b/docs/listing-gtm/VALIDATOR_REQUEST_MESSAGE.md
@@ -1,0 +1,21 @@
+# Validator Request Message (Send As-Is)
+
+Need one technical validator for the Coinstore GTM stack.
+
+Please run this 10-minute signoff:
+1. Open:
+   - `listing-landing.html`
+   - `supporter-opt-in.html`
+   - `proof-page.html`
+2. Validate holder + non-holder opt-in flow.
+3. Validate proof submission/copy flow.
+4. Confirm brand switch works (`?brand=regen` and `?brand=bridge`).
+5. Run:
+   - `npm run gtm:preflight`
+   - `node --check docs/listing-gtm/web/assets/regen-campaign.js`
+
+Reference doc:
+`docs/listing-gtm/TECH_SIGNOFF_PACKET.md`
+
+Please return:
+`[UTC] [name] [pass/fail] [blocking notes]`

--- a/docs/listing-gtm/WAIT_STATE_CHECKLIST.md
+++ b/docs/listing-gtm/WAIT_STATE_CHECKLIST.md
@@ -1,0 +1,32 @@
+# Wait State Checklist (Pre-PR)
+
+Status: READY TO PAUSE FOR VALIDATION
+
+## Completed Now
+1. 3-page build is done:
+   - `web/listing-landing.html`
+   - `web/supporter-opt-in.html`
+   - `web/proof-page.html`
+2. Anyone-can-opt-in flow is implemented (holder/non-holder/hybrid).
+3. Brand mode is implemented (`regen` and `bridge`).
+4. Ops templates and scripts are in place.
+5. PR draft and technical signoff packet are in place.
+6. Release bundles are excluded from PR scope via `.gitignore`.
+
+## Waiting On
+1. One technical validator to run signoff packet.
+2. Final live URLs (`LANDING_URL`, `PROOF_URL`, `RULES_URL`).
+
+## Resume Triggers
+Resume only when at least one of these is true:
+1. Validator returns blocker findings.
+2. Validator returns pass and asks for PR cut.
+3. Live URLs arrive.
+
+## Resume Commands
+1. Apply URLs:
+   `node docs/listing-gtm/scripts/apply-live-urls.mjs --landing <...> --proof <...> --rules <...>`
+2. Strict check:
+   `npm run gtm:preflight:strict`
+3. Open PR using:
+   `docs/listing-gtm/PR_DRAFT_COINSTORE_GTM.md`

--- a/docs/listing-gtm/fastlane-single-owner.md
+++ b/docs/listing-gtm/fastlane-single-owner.md
@@ -1,0 +1,37 @@
+# Fast Lane: Single-Owner Mode
+
+## Purpose
+Unblock execution when one person temporarily acts as:
+1. DRI
+2. Approver
+3. Publisher
+
+## Rule
+Use one temporary role:
+
+`TEMP_RELEASE_OWNER = <name>`
+
+This person can approve and publish all listing GTM artifacts until a broader owner group is assigned.
+
+## Guardrails
+1. Log every publish decision in writing.
+2. No financial promises in public copy.
+3. No production publish without one final checklist pass.
+
+## Work We Can Do Now (No URL Blockers)
+1. Finalize all owner matrices with `TEMP_RELEASE_OWNER`.
+2. Fill MM/runbook guardrails in `unit-6-exchange-mm-runbook.md`.
+3. Fill KPI thresholds and data sources in `unit-7-kpi-dashboard-spec.md`.
+4. Pre-draft Days 1-14 Telegram posts from `templates/telegram-14-day-posting-pack.md`.
+5. Dry run one proof submission and mod handling.
+
+## Work That Starts Immediately After URLs Arrive
+1. Set `LANDING_URL`, `PROOF_URL`, `RULES_URL` in `templates/telegram-link-values.md`.
+2. Replace all template tokens across Telegram files.
+3. Publish pinned message and Day 1 post.
+4. Publish landing and proof pages.
+
+## Release Decision Log
+Use this format for each ship action:
+
+`[UTC timestamp] [asset] [approved by TEMP_RELEASE_OWNER] [published by TEMP_RELEASE_OWNER] [notes]`

--- a/docs/listing-gtm/scripts/apply-live-urls.mjs
+++ b/docs/listing-gtm/scripts/apply-live-urls.mjs
@@ -1,0 +1,75 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--landing") out.landing = argv[i + 1];
+    if (arg === "--proof") out.proof = argv[i + 1];
+    if (arg === "--rules") out.rules = argv[i + 1];
+  }
+  return out;
+}
+
+function usage() {
+  return [
+    "Usage:",
+    "  node docs/listing-gtm/scripts/apply-live-urls.mjs \\",
+    "    --landing https://.../listing-landing.html \\",
+    "    --proof https://.../proof-page.html \\",
+    "    --rules https://.../supporter-opt-in.html#campaign-rules",
+    "",
+    "This replaces template tokens: {{LANDING_URL}}, {{PROOF_URL}}, {{RULES_URL}}",
+  ].join("\n");
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.landing || !args.proof || !args.rules) {
+  console.error(usage());
+  process.exit(1);
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const templatesDir = path.resolve(__dirname, "../templates");
+
+const targetFiles = [
+  "telegram-pinned-message.txt",
+  "telegram-daily-update.md",
+  "telegram-mod-quick-replies.md",
+  "telegram-14-day-posting-pack.md",
+];
+
+function patchTemplateTokens(filePath) {
+  let content = readFileSync(filePath, "utf8");
+  content = content
+    .replaceAll("{{LANDING_URL}}", args.landing)
+    .replaceAll("{{PROOF_URL}}", args.proof)
+    .replaceAll("{{RULES_URL}}", args.rules);
+  writeFileSync(filePath, content, "utf8");
+}
+
+for (const filename of targetFiles) {
+  patchTemplateTokens(path.join(templatesDir, filename));
+}
+
+const linkValuesPath = path.join(templatesDir, "telegram-link-values.md");
+let linkValues = readFileSync(linkValuesPath, "utf8");
+linkValues = linkValues
+  .replace(
+    /3\. `LANDING_URL`: `.*`/g,
+    `3. \`LANDING_URL\`: \`${args.landing}\``
+  )
+  .replace(
+    /4\. `PROOF_URL`: `.*`/g,
+    `4. \`PROOF_URL\`: \`${args.proof}\``
+  )
+  .replace(
+    /5\. `RULES_URL`: `.*`/g,
+    `5. \`RULES_URL\`: \`${args.rules}\``
+  );
+writeFileSync(linkValuesPath, linkValues, "utf8");
+
+console.log("Applied live URLs to listing GTM Telegram templates.");

--- a/docs/listing-gtm/scripts/create-release-bundle.mjs
+++ b/docs/listing-gtm/scripts/create-release-bundle.mjs
@@ -1,0 +1,67 @@
+import { cpSync, mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gtmRoot = path.resolve(__dirname, "..");
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function collectFiles(baseDir, acc = []) {
+  const entries = readdirSync(baseDir);
+  for (const entry of entries) {
+    const full = path.join(baseDir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      collectFiles(full, acc);
+    } else {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+const releaseRoot = path.join(gtmRoot, "release");
+mkdirSync(releaseRoot, { recursive: true });
+const bundleDir = path.join(releaseRoot, `coinstore-gtm-${timestamp()}`);
+mkdirSync(bundleDir, { recursive: true });
+
+const copyItems = [
+  "README.md",
+  "PR_DRAFT_COINSTORE_GTM.md",
+  "fastlane-single-owner.md",
+  "unit-2-listing-landing-page.md",
+  "unit-3-proof-page.md",
+  "unit-4-campaign-buy-participate-proof.md",
+  "unit-5-telegram-ops-kit.md",
+  "unit-6-exchange-mm-runbook.md",
+  "unit-7-kpi-dashboard-spec.md",
+  "templates",
+  "web",
+];
+
+for (const rel of copyItems) {
+  const src = path.join(gtmRoot, rel);
+  const dest = path.join(bundleDir, rel);
+  cpSync(src, dest, { recursive: true });
+}
+
+const files = collectFiles(bundleDir).map((file) => path.relative(bundleDir, file));
+const manifest = {
+  generated_at: new Date().toISOString(),
+  bundle_path: bundleDir,
+  file_count: files.length,
+  files,
+};
+
+writeFileSync(
+  path.join(bundleDir, "bundle-manifest.json"),
+  `${JSON.stringify(manifest, null, 2)}\n`,
+  "utf8"
+);
+
+console.log(`Created release bundle: ${bundleDir}`);
+console.log(`Files copied: ${files.length}`);

--- a/docs/listing-gtm/scripts/preflight-check.mjs
+++ b/docs/listing-gtm/scripts/preflight-check.mjs
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gtmRoot = path.resolve(__dirname, "..");
+
+const strictUrls = process.argv.includes("--strict-urls");
+
+const requiredFiles = [
+  "README.md",
+  "PR_DRAFT_COINSTORE_GTM.md",
+  "fastlane-single-owner.md",
+  "unit-2-listing-landing-page.md",
+  "unit-3-proof-page.md",
+  "unit-4-campaign-buy-participate-proof.md",
+  "unit-5-telegram-ops-kit.md",
+  "unit-6-exchange-mm-runbook.md",
+  "unit-7-kpi-dashboard-spec.md",
+  "web/listing-landing.html",
+  "web/supporter-opt-in.html",
+  "web/proof-page.html",
+  "web/proof-feed.json",
+  "web/assets/regen-campaign.css",
+  "web/assets/regen-campaign.js",
+  "templates/telegram-pinned-message.txt",
+  "templates/telegram-daily-update.md",
+  "templates/telegram-mod-quick-replies.md",
+  "templates/telegram-link-values.md",
+  "templates/telegram-14-day-posting-pack.md",
+];
+
+function loadFile(relativePath) {
+  return readFileSync(path.join(gtmRoot, relativePath), "utf8");
+}
+
+const errors = [];
+const warnings = [];
+
+for (const rel of requiredFiles) {
+  const full = path.join(gtmRoot, rel);
+  if (!existsSync(full)) {
+    errors.push(`Missing required file: ${rel}`);
+  }
+}
+
+function assertIncludes(relativePath, token) {
+  const content = loadFile(relativePath);
+  if (!content.includes(token)) {
+    errors.push(`Expected token "${token}" in ${relativePath}`);
+  }
+}
+
+assertIncludes("web/listing-landing.html", "./supporter-opt-in.html");
+assertIncludes("web/listing-landing.html", "./proof-page.html");
+assertIncludes("web/listing-landing.html", "data-brand-text=\"stackName\"");
+assertIncludes("web/listing-landing.html", "window.RegenCampaign.applyBrand()");
+assertIncludes("web/supporter-opt-in.html", "#campaign-rules");
+assertIncludes("web/supporter-opt-in.html", "Non-holder supporter");
+assertIncludes("web/supporter-opt-in.html", "window.RegenCampaign.applyBrand()");
+assertIncludes("web/proof-page.html", "./proof-feed.json");
+assertIncludes("web/proof-page.html", "window.RegenCampaign.applyBrand()");
+
+try {
+  const proofFeed = JSON.parse(loadFile("web/proof-feed.json"));
+  if (!proofFeed.updated_at) errors.push("proof-feed.json missing updated_at");
+  if (!proofFeed.totals) errors.push("proof-feed.json missing totals");
+  if (!Array.isArray(proofFeed.recent_retirements)) {
+    errors.push("proof-feed.json recent_retirements must be an array");
+  }
+  if (typeof proofFeed?.totals?.retirements !== "number") {
+    errors.push("proof-feed.json totals.retirements must be a number");
+  }
+  if (typeof proofFeed?.totals?.credits_retired !== "string") {
+    errors.push("proof-feed.json totals.credits_retired must be a string");
+  }
+} catch (error) {
+  errors.push(`proof-feed.json parse failed: ${error instanceof Error ? error.message : "unknown error"}`);
+}
+
+const urlTokenChecks = [
+  "templates/telegram-pinned-message.txt",
+  "templates/telegram-daily-update.md",
+  "templates/telegram-mod-quick-replies.md",
+  "templates/telegram-14-day-posting-pack.md",
+];
+
+for (const rel of urlTokenChecks) {
+  const content = loadFile(rel);
+  const unresolvedCount =
+    (content.match(/\{\{LANDING_URL\}\}/g) || []).length +
+    (content.match(/\{\{PROOF_URL\}\}/g) || []).length +
+    (content.match(/\{\{RULES_URL\}\}/g) || []).length;
+
+  if (unresolvedCount > 0) {
+    const msg = `${rel} has ${unresolvedCount} unresolved URL token(s)`;
+    if (strictUrls) {
+      errors.push(msg);
+    } else {
+      warnings.push(msg);
+    }
+  }
+}
+
+function printGroup(title, items) {
+  if (!items.length) return;
+  console.log(`\n${title}`);
+  for (const item of items) {
+    console.log(`- ${item}`);
+  }
+}
+
+console.log("Listing GTM preflight summary:");
+printGroup("Warnings", warnings);
+printGroup("Errors", errors);
+
+if (!warnings.length && !errors.length) {
+  console.log("\n- All checks passed.");
+}
+
+process.exit(errors.length ? 1 : 0);

--- a/docs/listing-gtm/scripts/update-proof-feed.mjs
+++ b/docs/listing-gtm/scripts/update-proof-feed.mjs
@@ -1,0 +1,95 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function usage() {
+  return [
+    "Usage:",
+    "  node docs/listing-gtm/scripts/update-proof-feed.mjs \\",
+    "    --retirement-id Wy123 \\",
+    "    --tx-hash ABCDEF \\",
+    "    --certificate-url https://regen.network/certificate/xyz \\",
+    "    --credits 1.250000 \\",
+    "    --notes \"Listing day batch\"",
+    "",
+    "Optional:",
+    "  --date YYYY-MM-DD         (default: today UTC date)",
+    "  --supporters 42           (set totals.supporters_opted_in)",
+    "  --feed /absolute/path.json (default: docs/listing-gtm/web/proof-feed.json)",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    if (!key.startsWith("--")) continue;
+    out[key.slice(2)] = argv[i + 1];
+  }
+  return out;
+}
+
+function formatDateUtc(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function formatCredits(value) {
+  return Number(value).toFixed(6);
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (!args["retirement-id"] || !args["tx-hash"] || !args["certificate-url"]) {
+  console.error(usage());
+  process.exit(1);
+}
+
+const creditsToAdd = Number(args.credits || "0");
+if (!Number.isFinite(creditsToAdd) || creditsToAdd < 0) {
+  console.error("--credits must be a non-negative number");
+  process.exit(1);
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultFeedPath = path.resolve(__dirname, "../web/proof-feed.json");
+const feedPath = args.feed ? path.resolve(process.cwd(), args.feed) : defaultFeedPath;
+
+const raw = readFileSync(feedPath, "utf8");
+const feed = JSON.parse(raw);
+
+if (!feed.totals || !Array.isArray(feed.recent_retirements)) {
+  throw new Error("Invalid proof feed schema");
+}
+
+const now = new Date();
+const entry = {
+  date: args.date || formatDateUtc(now),
+  retirement_id: args["retirement-id"],
+  tx_hash: args["tx-hash"],
+  certificate_url: args["certificate-url"],
+  notes: args.notes || "",
+};
+
+feed.updated_at = now.toISOString();
+feed.recent_retirements = [entry, ...feed.recent_retirements].slice(0, 50);
+feed.totals.retirements = Number(feed.totals.retirements || 0) + 1;
+
+const currentCredits = Number(feed.totals.credits_retired || "0");
+feed.totals.credits_retired = formatCredits(currentCredits + creditsToAdd);
+
+if (args.supporters !== undefined) {
+  const supporters = Number(args.supporters);
+  if (!Number.isInteger(supporters) || supporters < 0) {
+    throw new Error("--supporters must be a non-negative integer");
+  }
+  feed.totals.supporters_opted_in = supporters;
+}
+
+writeFileSync(feedPath, `${JSON.stringify(feed, null, 2)}\n`, "utf8");
+
+console.log("Updated proof feed:");
+console.log(`- feed: ${feedPath}`);
+console.log(`- retirement_id: ${entry.retirement_id}`);
+console.log(`- tx_hash: ${entry.tx_hash}`);
+console.log(`- credits_retired_total: ${feed.totals.credits_retired}`);
+console.log(`- retirements_total: ${feed.totals.retirements}`);

--- a/docs/listing-gtm/templates/kpi-dashboard-metrics.json
+++ b/docs/listing-gtm/templates/kpi-dashboard-metrics.json
@@ -1,0 +1,68 @@
+{
+  "version": 1,
+  "metrics": [
+    {
+      "id": "new_holders_weekly",
+      "name": "New holders (weekly)",
+      "owner": "",
+      "source": "",
+      "cadence": "weekly"
+    },
+    {
+      "id": "holder_retention_30d_pct",
+      "name": "30-day holder retention (%)",
+      "owner": "",
+      "source": "",
+      "cadence": "weekly"
+    },
+    {
+      "id": "participants_with_verified_action",
+      "name": "Participants with verified action",
+      "owner": "",
+      "source": "",
+      "cadence": "daily"
+    },
+    {
+      "id": "verification_actions_total",
+      "name": "Total verification actions",
+      "owner": "",
+      "source": "",
+      "cadence": "daily"
+    },
+    {
+      "id": "credits_retired_total",
+      "name": "Credits retired (total)",
+      "owner": "",
+      "source": "",
+      "cadence": "daily"
+    },
+    {
+      "id": "certificates_published_total",
+      "name": "Certificates published (total)",
+      "owner": "",
+      "source": "",
+      "cadence": "daily"
+    },
+    {
+      "id": "buy_sell_ratio",
+      "name": "Buy/Sell ratio",
+      "owner": "",
+      "source": "",
+      "cadence": "daily"
+    },
+    {
+      "id": "avg_spread_bps",
+      "name": "Average spread (bps)",
+      "owner": "",
+      "source": "",
+      "cadence": "daily"
+    },
+    {
+      "id": "top_of_book_depth_usd",
+      "name": "Top-of-book depth (USD)",
+      "owner": "",
+      "source": "",
+      "cadence": "daily"
+    }
+  ]
+}

--- a/docs/listing-gtm/templates/kpi-weekly.csv
+++ b/docs/listing-gtm/templates/kpi-weekly.csv
@@ -1,0 +1,2 @@
+week_start_utc,week_end_utc,new_holders_weekly,holder_retention_30d_pct,participants_with_verified_action,verification_actions_total,credits_retired_total,certificates_published_total,buy_sell_ratio,avg_spread_bps,top_of_book_depth_usd,notes
+2026-02-24,2026-03-02,0,0,0,0,0,0,0,0,0,baseline

--- a/docs/listing-gtm/templates/listing-day-ops-log.md
+++ b/docs/listing-gtm/templates/listing-day-ops-log.md
@@ -1,0 +1,35 @@
+# Listing Day Ops Log
+
+## Metadata
+- Date (UTC):
+- Listing pair:
+- Exchange:
+- Ops lead:
+- Backup lead:
+
+## Timeline Events
+| Time (UTC) | Event | Owner | Status | Notes |
+|---|---|---|---|---|
+| T-120m | Preflight checks complete |  |  |  |
+| T-60m | Change freeze active |  |  |  |
+| T-15m | Exchange + MM online check |  |  |  |
+| T0 | Listing opened |  |  |  |
+| T+15m | Market quality check 1 |  |  |  |
+| T+60m | Public status post |  |  |  |
+| T+4h | Mid-run report |  |  |  |
+| T+24h | Day-one summary |  |  |  |
+
+## Market Quality Snapshot
+- Observed spread:
+- Observed top-of-book depth:
+- Slippage check result:
+- Guardrail breaches:
+
+## Incident Log
+| Time (UTC) | Severity | Symptom | Impact | Owner | Action | Resolved |
+|---|---|---|---|---|---|---|
+|  |  |  |  |  |  |  |
+
+## Closeout
+- Final status:
+- Follow-up actions:

--- a/docs/listing-gtm/templates/telegram-14-day-posting-pack.md
+++ b/docs/listing-gtm/templates/telegram-14-day-posting-pack.md
@@ -1,0 +1,168 @@
+# Telegram 14-Day Posting Pack
+
+Replace `{{LANDING_URL}}`, `{{PROOF_URL}}`, and `{{RULES_URL}}` once, then post as-is.
+
+---
+
+## Day 1 - Launch
+Listing is live. Campaign is now active.
+
+Flow:
+1. Buy: https://www.coinstore.com/home
+2. Complete supporter opt-in (holder or non-holder): {{RULES_URL}}
+3. Submit proof with `#proof` (tx hash + certificate URL + wallet)
+
+Start here: {{LANDING_URL}}
+Live proof board: {{PROOF_URL}}
+Rules: {{RULES_URL}}
+
+---
+
+## Day 2 - How to Participate
+Quick participation reminder:
+
+1. Buy or top up on Coinstore
+2. Complete supporter opt-in (holder or non-holder) + one qualified action
+3. Submit proof before cutoff
+
+Campaign flow: {{LANDING_URL}}
+Proof board: {{PROOF_URL}}
+
+---
+
+## Day 3 - Proof Education
+How to verify proof in under 60 seconds:
+
+1. Open certificate URL
+2. Match retirement ID and tx hash
+3. Confirm date and reason
+
+Today’s references are on: {{PROOF_URL}}
+
+---
+
+## Day 4 - Midweek Push
+Midweek checkpoint. If you joined, now is the time to submit proof.
+
+Required format:
+`#proof`
+`tx_hash: ...`
+`certificate_url: ...`
+`wallet: ...`
+
+Rules: {{RULES_URL}}
+
+---
+
+## Day 5 - Safety Reminder
+Safety notice:
+1. No one from the team will ask for keys or seed phrase.
+2. No return guarantees are offered.
+3. Only verified proof submissions count.
+
+Official links:
+- Listing: https://www.coinstore.com/home
+- Landing: {{LANDING_URL}}
+- Proof: {{PROOF_URL}}
+
+---
+
+## Day 6 - Weekend Action
+Weekend action sprint:
+1. Buy or top up
+2. Complete one participation action
+3. Submit proof before day close
+
+Live proof feed: {{PROOF_URL}}
+
+---
+
+## Day 7 - Week 1 Recap
+Week 1 recap drops today.
+
+What we will publish:
+1. Verified actions count
+2. Proof highlights
+3. Next-week targets
+
+Track updates: {{PROOF_URL}}
+
+---
+
+## Day 8 - Week 2 Kickoff
+Week 2 starts now. Goal is consistent participation, not one-time activity.
+
+Do one action today:
+1. Buy
+2. Participate
+3. Prove
+
+Start: {{LANDING_URL}}
+
+---
+
+## Day 9 - Rule Clarification
+Rule clarification:
+1. Duplicate proof artifacts are invalid.
+2. Invalid tx/certificate references are rejected.
+3. Disputes are reviewed by ops + technical lead.
+
+Rules: {{RULES_URL}}
+
+---
+
+## Day 10 - Operator Update
+Operator update:
+1. Market status monitored continuously.
+2. Proof feed updated daily.
+3. Incident path is active for urgent issues.
+
+Proof board: {{PROOF_URL}}
+
+---
+
+## Day 11 - Community Recognition
+Recognition day:
+We will highlight top verified participants from this cycle.
+
+To qualify:
+1. Ensure your proof submission is complete.
+2. Submit before cutoff.
+
+Reference: {{RULES_URL}}
+
+---
+
+## Day 12 - Final Stretch
+Final stretch starts now.
+
+If you have not submitted proof yet:
+1. Complete your participation action
+2. Submit full proof block today
+
+Instructions: {{LANDING_URL}}
+
+---
+
+## Day 13 - Last Full Day
+Last full day before campaign close.
+
+Checklist:
+1. Buy/top up complete
+2. Participation complete
+3. Proof submitted and acknowledged
+
+Proof board: {{PROOF_URL}}
+
+---
+
+## Day 14 - Close and Next Steps
+Campaign closes today at cutoff.
+
+After close we will publish:
+1. Final verified action totals
+2. Proof summary
+3. Next cycle schedule
+
+Thanks to everyone who participated with verified proof.
+Rules and closeout process: {{RULES_URL}}

--- a/docs/listing-gtm/templates/telegram-daily-update.md
+++ b/docs/listing-gtm/templates/telegram-daily-update.md
@@ -1,0 +1,24 @@
+# Daily Campaign Update - {{DATE_UTC}}
+
+## Status
+- Day: {{DAY_NUMBER}} / 14
+- Campaign phase: {{PHASE}}
+- Time remaining: {{TIME_REMAINING}}
+
+## Scoreboard
+- New participants today: {{NEW_PARTICIPANTS}}
+- Verified actions today: {{VERIFIED_ACTIONS}}
+- Total verified actions: {{TOTAL_VERIFIED_ACTIONS}}
+
+## Proof Highlight
+- Retirement/certificate reference: {{PROOF_REFERENCE}}
+- Verification link: {{PROOF_URL}}
+
+## Action for Today
+1. Buy or top up via listing venue: https://www.coinstore.com/home
+2. Complete supporter opt-in (holder or non-holder): {{RULES_URL}}
+3. Submit proof before cutoff: {{SUBMISSION_PROCESS}}
+
+## Reminder
+- No return guarantees are offered.
+- Only verified submissions count.

--- a/docs/listing-gtm/templates/telegram-link-values.md
+++ b/docs/listing-gtm/templates/telegram-link-values.md
@@ -1,0 +1,14 @@
+# Telegram Link Values (Set Once)
+
+Use these values across pinned messages, daily updates, and mod replies.
+
+1. `LISTING_URL`: `https://www.coinstore.com/home`
+2. `TELEGRAM_COMMUNITY_URL`: `https://t.me/regennetwork_public`
+3. `LANDING_URL`: `{{SET_THIS_TO_YOUR_PUBLISHED_LANDING_PAGE}}`
+4. `PROOF_URL`: `{{SET_THIS_TO_YOUR_PUBLISHED_PROOF_PAGE}}`
+5. `RULES_URL`: `{{SET_THIS_TO_YOUR_PUBLISHED_SUPPORTER_OPTIN_PAGE}}#campaign-rules`
+
+Proof submission process token:
+
+`SUBMISSION_PROCESS`:
+`Post in this group with #proof + tx_hash + certificate_url + wallet before daily cutoff.`

--- a/docs/listing-gtm/templates/telegram-mod-quick-replies.md
+++ b/docs/listing-gtm/templates/telegram-mod-quick-replies.md
@@ -1,0 +1,22 @@
+# Moderator Quick Replies
+
+## Price Prediction Request
+We cannot provide price predictions or investment advice. Campaign details and participation rules are here: {{RULES_URL}}
+
+## How to Participate
+Steps are simple: buy (optional for non-holders), complete supporter opt-in, complete one participation action, then submit proof. Start here: {{LANDING_URL}}
+
+## How to Verify Proof
+Use the proof board to check certificate or transaction references: {{PROOF_URL}}
+
+## Submission Rejected
+Please share your submission ID and proof reference with mods. Duplicate or invalid proof artifacts are not eligible.
+
+## Exchange Issue
+Please share timestamp, screenshot, and issue details. We will route this to exchange ops immediately.
+
+## Scam Warning
+Admins never ask for private keys or seed phrases. Only trust links pinned in this group.
+
+## Where to Buy
+Use the official listing venue link only: https://www.coinstore.com/home

--- a/docs/listing-gtm/templates/telegram-pinned-message.txt
+++ b/docs/listing-gtm/templates/telegram-pinned-message.txt
@@ -1,0 +1,24 @@
+Listing GTM: Buy + Participate + Proof
+
+This campaign is focused on long-term aligned participation.
+Anyone can opt in (holder or non-holder supporter).
+
+How to join:
+1. Buy on Coinstore: https://www.coinstore.com/home
+2. Complete supporter opt-in + one regeneration participation action.
+3. Submit proof in this group using:
+   #proof
+   tx_hash: <your_tx_hash>
+   certificate_url: <your_certificate_url>
+   wallet: <your_wallet>
+
+Live links:
+- Landing page: {{LANDING_URL}}
+- Proof board: {{PROOF_URL}}
+- Campaign rules: {{RULES_URL}}
+- Telegram community (external): https://t.me/regennetwork_public
+
+Important:
+- No financial advice or return promises.
+- Verification is required for campaign credit.
+- Duplicate or fraudulent submissions are disqualified.

--- a/docs/listing-gtm/unit-10-ten-minute-technical-signoff.md
+++ b/docs/listing-gtm/unit-10-ten-minute-technical-signoff.md
@@ -1,0 +1,36 @@
+# Unit 10: Ten-Minute Technical Signoff
+
+## Objective
+Get one technical signer to approve coherence and operational readiness fast.
+
+## Reference
+Use:
+`docs/listing-gtm/TECH_SIGNOFF_PACKET.md`
+
+## Signoff Path (10 minutes)
+1. Open all 3 pages and verify navigation.
+2. Submit one holder profile on supporter page.
+3. Submit one non-holder profile on supporter page.
+4. Copy `#supporter-optin` block.
+5. Submit one local proof on proof page.
+6. Copy `#proof` block.
+7. Confirm proof feed rows render.
+8. Run:
+   - `npm run gtm:preflight`
+   - `node --check docs/listing-gtm/web/assets/regen-campaign.js`
+
+## Approval Output
+Record in one line:
+`[UTC] [signer] [pass/fail] [blocking notes]`
+
+## Owner Matrix
+- DRI: TEMP_RELEASE_OWNER
+- Approver: TEMP_RELEASE_OWNER
+- Publisher: TEMP_RELEASE_OWNER
+- Fallback Publisher: TEMP_RELEASE_OWNER
+- Target Time (UTC): T0-10h
+
+## Definition of Done
+1. One named technical signer completes the path.
+2. Pass/fail line recorded.
+3. Any blockers converted to explicit tasks.

--- a/docs/listing-gtm/unit-11-pr-cut-and-review-routing.md
+++ b/docs/listing-gtm/unit-11-pr-cut-and-review-routing.md
@@ -1,0 +1,34 @@
+# Unit 11: PR Cut and Review Routing
+
+## Objective
+Open a targeted PR that a busy technical lead can approve with minimal friction.
+
+## PR Positioning
+Use a listing-specific title and body:
+- Title/body source:
+  `docs/listing-gtm/PR_DRAFT_COINSTORE_GTM.md`
+
+## Required Review Assignments
+1. Primary technical reviewer (e.g., bridge.eco or Regen R&D).
+2. Secondary fallback reviewer.
+3. Final publisher.
+
+## Execution Steps
+1. Create branch with `codex/` prefix.
+2. Commit GTM stack changes.
+3. Open PR using draft title/body.
+4. Request review from primary + fallback.
+5. Post PR link in team Telegram with ask:
+   `Need technical signoff for listing deployment path.`
+
+## Owner Matrix
+- DRI: TEMP_RELEASE_OWNER
+- Approver: TEMP_RELEASE_OWNER
+- Publisher: TEMP_RELEASE_OWNER
+- Fallback Publisher: TEMP_RELEASE_OWNER
+- Target Time (UTC): T0-8h
+
+## Definition of Done
+1. PR opened with listing-targeted title.
+2. Reviewer assignments are explicit.
+3. Merge/publish owner is identified in PR context block.

--- a/docs/listing-gtm/unit-12-listing-day-rehearsal.md
+++ b/docs/listing-gtm/unit-12-listing-day-rehearsal.md
@@ -1,0 +1,37 @@
+# Unit 12: Listing-Day Rehearsal
+
+## Objective
+Run a full dry run before launch to reduce operational surprises.
+
+## Scope
+1. Simulate supporter opt-in submission.
+2. Simulate proof submission and verification.
+3. Simulate community moderation + escalation.
+
+## Required References
+1. `templates/listing-day-ops-log.md`
+2. `templates/telegram-mod-quick-replies.md`
+3. `web/supporter-opt-in.html`
+4. `web/proof-page.html`
+
+## Rehearsal Script
+1. Post one mock `#supporter-optin` block.
+2. Post one mock `#proof` block.
+3. Update proof feed with:
+   ```bash
+   node docs/listing-gtm/scripts/update-proof-feed.mjs --retirement-id WyDryRun001 --tx-hash DryRunTx001 --certificate-url https://regen.network/certificate/dry-run --credits 0.100000 --notes "Dry run"
+   ```
+4. Run one moderator response cycle from quick replies.
+5. Log timestamps and outcomes in ops log template.
+
+## Owner Matrix
+- DRI: TEMP_RELEASE_OWNER
+- Approver: TEMP_RELEASE_OWNER
+- Publisher: TEMP_RELEASE_OWNER
+- Fallback Publisher: TEMP_RELEASE_OWNER
+- Target Time (UTC): T0-6h
+
+## Definition of Done
+1. Dry run executed end-to-end.
+2. Ops log completed with notes.
+3. Any failure points documented with owner and fix ETA.

--- a/docs/listing-gtm/unit-13-day-0-content-queue.md
+++ b/docs/listing-gtm/unit-13-day-0-content-queue.md
@@ -1,0 +1,39 @@
+# Unit 13: Day-0 Content Queue
+
+## Objective
+Pre-stage core community posts so launch communications do not block on manual drafting.
+
+## Scope
+1. Pinned message.
+2. Day 1, Day 2, Day 3 campaign posts.
+3. One emergency clarification post.
+
+## Source Files
+1. `templates/telegram-pinned-message.txt`
+2. `templates/telegram-14-day-posting-pack.md`
+3. `templates/telegram-mod-quick-replies.md`
+
+## Queue Build Steps
+1. Pull Day 1-3 content blocks into scheduler/draft queue.
+2. Confirm links match hydrated values.
+3. Add one fallback safety post:
+   - no financial advice
+   - official links only
+   - proof format reminder
+4. Pre-approve all four messages.
+
+## Fallback Safety Post
+`Official launch reminder: use only pinned links, no one will ask for seed phrase, and only verified #proof submissions count.`
+
+## Owner Matrix
+- DRI: TEMP_RELEASE_OWNER
+- Approver: TEMP_RELEASE_OWNER
+- Publisher: TEMP_RELEASE_OWNER
+- Fallback Publisher: TEMP_RELEASE_OWNER
+- Target Time (UTC): T0-4h
+
+## Definition of Done
+1. Pinned message staged.
+2. Day 1-3 posts staged.
+3. Safety fallback post staged.
+4. Publisher confirms final send order.

--- a/docs/listing-gtm/unit-2-listing-landing-page.md
+++ b/docs/listing-gtm/unit-2-listing-landing-page.md
@@ -1,0 +1,70 @@
+# Unit 2: Listing Landing Page
+
+## Objective
+Convert exchange listing traffic into long-term aligned holders who take the next step:
+
+`Buy -> Participate -> Proof`
+
+Secondary path:
+
+`Opt in as non-holder supporter -> Participate -> Proof`
+
+## Page Goal (v1)
+One page that answers:
+1. Why this token exists.
+2. Why someone should stay involved after buying.
+3. What action to take next.
+
+## Required Sections
+1. Hero
+- Headline: `AI usage funds verified ecological regeneration.`
+- Subhead: `Every retirement is on-chain and publicly verifiable.`
+- CTA buttons:
+  - `Trade on Coinstore`
+  - `See Live Proof`
+  - `Join Telegram`
+
+2. Why Hold (utility, not price promises)
+- Access to participation campaigns.
+- Priority access to product/community programs.
+- Public attribution to impact actions.
+
+3. How It Works
+- `Buy token`
+- `Participate in regeneration action`
+- `Verify proof on-chain`
+
+4. Trust + Safety
+- No investment return promises.
+- Transparent methodology and verification links.
+- Clear risk and disclosure language.
+
+5. FAQ (short)
+- What is this token used for?
+- How is impact verified?
+- Is this a financial product?
+- Where can I track retirements?
+
+## Ready-to-Paste Hero Copy
+`Regen for AI turns compute activity into verifiable ecological regeneration.`
+
+`This is not a hype cycle token page. This is a participation and proof system: buy, participate, and verify on-chain.`
+
+## Owner Matrix (fill now)
+- DRI: TEMP_RELEASE_OWNER
+- Approver: TEMP_RELEASE_OWNER
+- Publisher: TEMP_RELEASE_OWNER
+- Fallback Publisher: TEMP_RELEASE_OWNER
+- Publish Deadline (UTC): T0-24h
+
+## Definition of Done
+1. URL live and mobile-tested.
+2. All three CTA links active.
+3. Compliance disclaimer present.
+4. Approved by Approver and published by Publisher.
+
+## Publish Checklist
+1. Final copy check.
+2. Link QA (Coinstore, proof page, Telegram).
+3. Mobile and desktop screenshots captured.
+4. Post URL in Telegram pinned message.

--- a/docs/listing-gtm/unit-3-proof-page.md
+++ b/docs/listing-gtm/unit-3-proof-page.md
@@ -1,0 +1,71 @@
+# Unit 3: Proof Page
+
+## Objective
+Make trust visible. Show that participation results in verifiable regeneration activity.
+
+## Page Goal (v1)
+Single public page with:
+1. Live or daily-updated impact totals.
+2. Recent certificates and transaction references.
+3. A clear verification path.
+
+## Required Sections
+1. Impact Counter
+- Total credits retired
+- Total retirements
+- Latest update timestamp
+
+2. Recent Proof Feed
+- Last 10 retirement entries with:
+  - Date
+  - Credit/project reference
+  - Retirement/certificate ID
+  - Transaction hash or link
+
+3. Verification Guide
+- `How to verify a retirement in under 60 seconds`
+- Links to explorer/indexer/certificate pages
+
+4. Method Note
+- Clarify this is regenerative contribution tracking.
+- Avoid "carbon neutral" claims unless legally reviewed.
+
+## Data Contract (v1, manual-safe)
+Use this structure for updates:
+
+```json
+{
+  "updated_at": "2026-02-24T00:00:00Z",
+  "totals": {
+    "retirements": 0,
+    "credits_retired": "0.000000"
+  },
+  "recent": [
+    {
+      "date": "2026-02-24",
+      "retirement_id": "Wy...",
+      "tx_hash": "ABC...",
+      "certificate_url": "https://regen.network/certificate/...",
+      "notes": "Monthly pooled retirement"
+    }
+  ]
+}
+```
+
+## Owner Matrix (fill now)
+- DRI: TEMP_RELEASE_OWNER
+- Approver: TEMP_RELEASE_OWNER
+- Publisher: TEMP_RELEASE_OWNER
+- Fallback Publisher: TEMP_RELEASE_OWNER
+- Publish Deadline (UTC): T0-24h
+
+## Definition of Done
+1. Public proof URL is live.
+2. At least 3 real proof entries displayed (or marked pending if pre-listing).
+3. Verification instructions are visible and tested.
+4. Timestamp reflects current update.
+
+## Operating Cadence
+1. Update proof feed daily during listing week.
+2. Pin latest proof link in Telegram.
+3. Include proof snapshot in weekly call notes.

--- a/docs/listing-gtm/unit-4-campaign-buy-participate-proof.md
+++ b/docs/listing-gtm/unit-4-campaign-buy-participate-proof.md
@@ -1,0 +1,66 @@
+# Unit 4: Campaign Spec - Buy + Participate + Proof
+
+## Objective
+Use listing attention to create repeat participation behavior, not one-day speculation.
+
+Campaign anchor:
+
+`Buy -> Participate -> Proof`
+
+## Campaign Window
+- Start: Listing Day (T0)
+- End: T0 + 14 days
+- Reporting: Daily short update in Telegram
+
+## Eligibility (simple v1)
+1. Complete a buy action on listing venue.
+2. Complete one participation action (retirement, contribution, or verified regeneration action).
+3. Submit proof artifact (tx hash, certificate URL, or approved equivalent).
+
+Alternative eligibility path (non-holder):
+1. Complete supporter opt-in.
+2. Complete one participation action.
+3. Submit proof artifact.
+
+## Reward Design Principles
+1. No return guarantees.
+2. Prefer non-cash/status rewards (recognition, access, badges, priority participation).
+3. Publish transparent scoring criteria before start.
+
+## Recommended Scoring (v1)
+1. Buy action: 1 point
+2. Participation action: 2 points
+3. Proof submission: 2 points
+4. Weekly streak bonus: +2 points
+
+## Anti-Abuse Rules (minimum)
+1. One identity per participant (email/Telegram + wallet check).
+2. Duplicate proof artifacts invalid.
+3. Team reserves right to disqualify clear sybil behavior.
+
+## Daily Ops Checklist (listing week)
+1. Post daily standings/time-left update.
+2. Publish proof highlights (top verified actions).
+3. Answer FAQ and direct users to landing + proof pages.
+4. Log incidents or rule disputes for next call.
+
+## Owner Matrix (fill now)
+- DRI: TEMP_RELEASE_OWNER
+- Approver: TEMP_RELEASE_OWNER
+- Publisher: TEMP_RELEASE_OWNER
+- Fallback Publisher: TEMP_RELEASE_OWNER
+- Launch Deadline (UTC): T0
+
+## Definition of Done
+1. Campaign rules published publicly.
+2. Submission format documented.
+3. Daily operator assigned.
+4. Dispute path defined.
+5. End-of-campaign recap template ready.
+
+## Recap Template (post-campaign)
+1. Total participants
+2. Total verified actions
+3. Total proof artifacts
+4. Top learnings
+5. Next-cycle improvements

--- a/docs/listing-gtm/unit-5-telegram-ops-kit.md
+++ b/docs/listing-gtm/unit-5-telegram-ops-kit.md
@@ -1,0 +1,51 @@
+# Unit 5: Telegram Ops Kit
+
+## Objective
+Keep community communication clear, repetitive, and action-focused during listing week.
+
+## Core Rule
+Every post should map to one of three outcomes:
+1. Buy
+2. Participate
+3. Verify proof
+
+## Required Assets
+1. Pinned message
+2. Daily update template
+3. Moderator quick replies
+4. Escalation protocol for high-risk questions
+
+## Posting Cadence (14-day campaign)
+1. One daily campaign status update
+2. One daily proof highlight
+3. One daily FAQ or education post
+4. One reminder before day close
+
+## Content Types
+1. `Status`: where campaign stands
+2. `Proof`: real certificate or tx evidence
+3. `Action`: exact next step users should take
+4. `Safety`: no financial promises, risk disclosure
+
+## Escalation Rules
+1. Price prediction or investment advice requests -> use approved disclaimer and redirect to campaign rules.
+2. Technical proof disputes -> tag technical lead and pause public argument.
+3. Exchange operations complaints -> route to exchange ops owner.
+
+## Owner Matrix (fill now)
+- DRI: TEMP_RELEASE_OWNER
+- Approver: TEMP_RELEASE_OWNER
+- Publisher: TEMP_RELEASE_OWNER
+- Fallback Publisher: TEMP_RELEASE_OWNER
+- Start Date (UTC): T0
+
+## Definition of Done
+1. Pinned message posted and locked.
+2. 14 daily updates pre-drafted.
+3. Moderator quick replies approved.
+4. Escalation owner list published internally.
+
+## File References
+1. `templates/telegram-pinned-message.txt`
+2. `templates/telegram-daily-update.md`
+3. `templates/telegram-mod-quick-replies.md`

--- a/docs/listing-gtm/unit-6-exchange-mm-runbook.md
+++ b/docs/listing-gtm/unit-6-exchange-mm-runbook.md
@@ -1,0 +1,62 @@
+# Unit 6: Exchange and Market-Making Runbook
+
+## Objective
+Protect market quality and response speed during listing launch and the first 14 days.
+
+## Scope
+1. Exchange listing coordination
+2. Market-making guardrails
+3. Incident response and escalation
+
+## Pre-Listing Checklist
+1. Confirm final listing timestamp and timezone.
+2. Confirm spot pair symbol and decimals.
+3. Confirm deposit/withdrawal status windows.
+4. Confirm market-maker contact channels and backup contacts.
+5. Confirm spread/depth guardrails in writing.
+6. Confirm internal incident owner and 24h reachability.
+
+## Market Quality Guardrails (fill exact numbers)
+1. Target spread:
+2. Minimum top-of-book depth:
+3. Max tolerated slippage at standard clip:
+4. Requote interval:
+5. Circuit-breaker condition:
+
+## Listing-Day Timeline
+1. T-120 min: final systems check, confirm contacts online.
+2. T-60 min: freeze non-critical changes, open ops log.
+3. T-15 min: verify exchange status page and internal channels.
+4. T0: listing open, publish official links in Telegram.
+5. T+15 min: first market quality check.
+6. T+60 min: first public proof/status post.
+7. T+4h: publish summary and next checkpoint.
+8. T+24h: day-one report.
+
+## Incident Severity
+1. Sev 1: trading unavailable, wrong market config, or security event.
+2. Sev 2: sustained spread/depth outside guardrails.
+3. Sev 3: isolated user complaints or temporary latency.
+
+## Incident Response
+1. Log timestamp, symptom, and impact.
+2. Assign incident lead.
+3. Notify exchange and market-maker within 5 minutes for Sev 1/2.
+4. Publish community update when user impact exists.
+5. Close with root cause and mitigation action.
+
+## Owner Matrix (fill now)
+- DRI: TEMP_RELEASE_OWNER
+- Approver: TEMP_RELEASE_OWNER
+- Publisher: TEMP_RELEASE_OWNER
+- Fallback Publisher: TEMP_RELEASE_OWNER
+- Launch Date (UTC): T0
+
+## Definition of Done
+1. Guardrails documented and signed off.
+2. Contacts and escalation tree tested.
+3. Listing-day timeline assigned by owner.
+4. Incident template ready.
+
+## File Reference
+1. `templates/listing-day-ops-log.md`

--- a/docs/listing-gtm/unit-7-kpi-dashboard-spec.md
+++ b/docs/listing-gtm/unit-7-kpi-dashboard-spec.md
@@ -1,0 +1,61 @@
+# Unit 7: KPI Dashboard Spec
+
+## Objective
+Measure whether listing attention converts into durable, proof-linked participation.
+
+## KPI Categories
+1. Holder growth
+2. Holder retention
+3. Participation actions
+4. Proof outputs
+5. Market quality
+
+## Weekly Core KPIs
+1. `new_holders_weekly`
+2. `holder_retention_30d_pct`
+3. `participants_with_verified_action`
+4. `verification_actions_total`
+5. `credits_retired_total`
+6. `certificates_published_total`
+7. `buy_sell_ratio`
+8. `avg_spread_bps`
+9. `top_of_book_depth_usd`
+
+## KPI Definitions
+1. `holder_retention_30d_pct` = holders from day N still holding on day N+30 / holders on day N * 100
+2. `participants_with_verified_action` = distinct participants with at least one accepted proof artifact
+3. `buy_sell_ratio` = buy volume / sell volume over same period
+4. `avg_spread_bps` = average best ask-bid spread in basis points during tracking window
+
+## Data Sources (fill now)
+1. Exchange reporting source:
+2. Market-maker reporting source:
+3. On-chain/indexer source:
+4. Internal campaign database/source:
+
+## Cadence
+1. Daily snapshot during first 14 days
+2. Weekly rollup for leadership call
+3. Monthly summary after listing cycle
+
+## Thresholds (fill exact targets)
+1. Green threshold:
+2. Yellow threshold:
+3. Red threshold:
+
+## Owner Matrix (fill now)
+- DRI: TEMP_RELEASE_OWNER
+- Approver: TEMP_RELEASE_OWNER
+- Publisher: TEMP_RELEASE_OWNER
+- Fallback Publisher: TEMP_RELEASE_OWNER
+- First Reporting Date (UTC): T0+24h
+
+## Definition of Done
+1. KPI sheet created with all required columns.
+2. Data source owner assigned for each metric.
+3. First baseline snapshot completed.
+4. Weekly reporting rhythm active.
+
+## File References
+1. `templates/kpi-weekly.csv`
+2. `templates/kpi-dashboard-metrics.json`

--- a/docs/listing-gtm/unit-8-staging-publish.md
+++ b/docs/listing-gtm/unit-8-staging-publish.md
@@ -1,0 +1,40 @@
+# Unit 8: Staging Publish
+
+## Objective
+Publish the 3-page stack to staging so technical lead can validate a real URL flow.
+
+## Scope
+1. Upload web bundle preserving relative paths.
+2. Verify navigation and assets load.
+3. Confirm proof feed read path works.
+
+## Required Inputs
+1. Staging host or static bucket access.
+2. Publisher credentials.
+3. Bundle path:
+   `/Users/EcoWealth/dev/regenerative-compute/docs/listing-gtm/release/coinstore-gtm-2026-02-24T21-05-48-243Z/web`
+
+## Execution Steps
+1. Upload entire `web/` folder contents as one deployment.
+2. Open:
+   - `listing-landing.html`
+   - `supporter-opt-in.html`
+   - `proof-page.html`
+3. Validate:
+   - top nav links
+   - styles and scripts
+   - proof feed table rendering
+4. Capture one screenshot per page for signoff record.
+
+## Owner Matrix
+- DRI: TEMP_RELEASE_OWNER
+- Approver: TEMP_RELEASE_OWNER
+- Publisher: TEMP_RELEASE_OWNER
+- Fallback Publisher: TEMP_RELEASE_OWNER
+- Target Time (UTC): T0-24h
+
+## Definition of Done
+1. Staging URL live.
+2. All three pages accessible from top nav.
+3. No broken asset paths.
+4. Screenshots posted to internal ops thread.

--- a/docs/listing-gtm/unit-9-url-hydration-and-strict-preflight.md
+++ b/docs/listing-gtm/unit-9-url-hydration-and-strict-preflight.md
@@ -1,0 +1,40 @@
+# Unit 9: URL Hydration and Strict Preflight
+
+## Objective
+Replace placeholder URLs and verify launch artifacts are fully production-ready.
+
+## Scope
+1. Inject live URLs into templates.
+2. Run strict preflight checks.
+3. Produce pass/fail record.
+
+## Required Inputs
+1. `LANDING_URL`
+2. `PROOF_URL`
+3. `RULES_URL` (recommended: supporter opt-in page with `#campaign-rules`)
+
+## Commands
+```bash
+node docs/listing-gtm/scripts/apply-live-urls.mjs --landing <LANDING_URL> --proof <PROOF_URL> --rules <RULES_URL>
+npm run gtm:preflight:strict
+```
+
+## Verification
+1. Check templates:
+   - `templates/telegram-pinned-message.txt`
+   - `templates/telegram-daily-update.md`
+   - `templates/telegram-mod-quick-replies.md`
+   - `templates/telegram-14-day-posting-pack.md`
+2. Ensure no `{{LANDING_URL}}`, `{{PROOF_URL}}`, `{{RULES_URL}}` tokens remain.
+
+## Owner Matrix
+- DRI: TEMP_RELEASE_OWNER
+- Approver: TEMP_RELEASE_OWNER
+- Publisher: TEMP_RELEASE_OWNER
+- Fallback Publisher: TEMP_RELEASE_OWNER
+- Target Time (UTC): T0-12h
+
+## Definition of Done
+1. URL patch command completed successfully.
+2. `gtm:preflight:strict` passes.
+3. URL token audit confirms no unresolved placeholders.

--- a/docs/listing-gtm/web/README.md
+++ b/docs/listing-gtm/web/README.md
@@ -1,0 +1,43 @@
+# Listing Web Stack
+
+Three-page launch flow:
+
+1. `listing-landing.html`
+2. `supporter-opt-in.html`
+3. `proof-page.html`
+
+Supporting assets:
+
+1. `assets/regen-campaign.css`
+2. `assets/regen-campaign.js`
+3. `proof-feed.json`
+
+## Publish Order
+1. Publish all files in this folder with relative paths intact.
+2. Set final public URLs in `../templates/telegram-link-values.md`.
+3. Use `supporter-opt-in.html#campaign-rules` as `RULES_URL`.
+4. Optional fast patch command when URLs are ready:
+   `node ../scripts/apply-live-urls.mjs --landing <...> --proof <...> --rules <...>`
+5. Run preflight:
+   `npm run gtm:preflight`
+6. For launch-time strict check (all URLs must be live):
+   `npm run gtm:preflight:strict`
+
+## Brand Mode
+Default brand: `regen`
+
+Switch to Bridge.eco mode by adding query param:
+- `listing-landing.html?brand=bridge`
+- `supporter-opt-in.html?brand=bridge`
+- `proof-page.html?brand=bridge`
+
+Notes:
+1. Nav links preserve `brand` query once selected.
+2. Brand mode is remembered in browser local storage.
+3. Supported values: `regen`, `bridge`, `bridge.eco`.
+
+## Live Data Update
+Update `proof-feed.json` during listing week. `proof-page.html` loads this file directly and falls back to sample data only if fetch fails.
+
+Update command:
+`node ../scripts/update-proof-feed.mjs --retirement-id <...> --tx-hash <...> --certificate-url <...> --credits <...>`

--- a/docs/listing-gtm/web/assets/regen-campaign.css
+++ b/docs/listing-gtm/web/assets/regen-campaign.css
@@ -1,0 +1,516 @@
+:root {
+  --ink-900: #102133;
+  --ink-700: #324b63;
+  --ink-500: #5f7a94;
+  --line-300: #a8bfd2;
+  --line-200: #cbdbe7;
+  --paper: rgba(255, 255, 255, 0.9);
+  --mist: #eef4fa;
+  --leaf: #0f7a58;
+  --leaf-strong: #09583f;
+  --primary-grad-top: #148861;
+  --primary-grad-bottom: #0c6a4d;
+  --sky: #e3f0ff;
+  --mint: #ddf3e7;
+  --warn-bg: #fff4ea;
+  --warn-ink: #7f4f2c;
+  --brand-dot-top: #0b9367;
+  --brand-dot-bottom: #056348;
+  --brand-dot-shadow: rgba(15, 122, 88, 0.14);
+  --kicker-line: #8cccad;
+  --kicker-bg: #e7f7ee;
+  --kicker-ink: #0a6f4d;
+  --loop-dot-line: #8ec9af;
+  --loop-dot-ink: #0e6649;
+  --message-line: #99ccba;
+  --message-bg: #ecf8f2;
+  --message-ink: #0a5f43;
+  --body-accent: #d7eadf;
+  --body-grad-start: #eff4f9;
+  --body-grad-end: #dfe9f3;
+}
+
+body[data-brand="bridge"] {
+  --line-300: #9ebcd7;
+  --line-200: #c7daeb;
+  --mist: #e9f2fb;
+  --leaf: #0b67ab;
+  --leaf-strong: #0a4f82;
+  --primary-grad-top: #0f79c3;
+  --primary-grad-bottom: #0a5a93;
+  --sky: #e1eefb;
+  --mint: #e4f0fb;
+  --brand-dot-top: #33b2ef;
+  --brand-dot-bottom: #1f6cb9;
+  --brand-dot-shadow: rgba(34, 126, 206, 0.18);
+  --kicker-line: #8fbbdf;
+  --kicker-bg: #e5f1fb;
+  --kicker-ink: #0c5e96;
+  --loop-dot-line: #8fb3d8;
+  --loop-dot-ink: #135989;
+  --message-line: #9fc1df;
+  --message-bg: #edf5fc;
+  --message-ink: #114d78;
+  --body-accent: #d6e6f5;
+  --body-grad-start: #eef4fb;
+  --body-grad-end: #dee9f7;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  color: var(--ink-900);
+  font-family: "Sora", "Avenir Next", sans-serif;
+  background:
+    radial-gradient(110% 95% at 5% 0%, #ffffff 0%, transparent 60%),
+    radial-gradient(100% 90% at 100% 100%, var(--body-accent) 0%, transparent 65%),
+    linear-gradient(155deg, var(--body-grad-start), var(--body-grad-end));
+}
+
+a {
+  color: var(--leaf);
+}
+
+.page-shell {
+  width: min(1120px, 100% - 2rem);
+  margin: 1.2rem auto 2rem;
+}
+
+.top-nav {
+  position: sticky;
+  top: 0.8rem;
+  z-index: 30;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid var(--line-300);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 14px 30px rgba(16, 33, 51, 0.1);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-family: "Fraunces", "Georgia", serif;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--ink-900);
+  text-decoration: none;
+}
+
+.brand-dot {
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 999px;
+  background: linear-gradient(180deg, var(--brand-dot-top), var(--brand-dot-bottom));
+  box-shadow: 0 0 0 4px var(--brand-dot-shadow);
+}
+
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.nav-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line-300);
+  border-radius: 999px;
+  padding: 0.45rem 0.8rem;
+  text-decoration: none;
+  font-size: 0.86rem;
+  color: var(--ink-700);
+  background: #ffffff;
+}
+
+.nav-link.is-active {
+  color: #ffffff;
+  background: var(--leaf);
+  border-color: var(--leaf-strong);
+}
+
+.hero {
+  margin-top: 0.95rem;
+  border: 1px solid var(--line-300);
+  border-radius: 22px;
+  background: var(--paper);
+  box-shadow: 0 22px 48px rgba(16, 33, 51, 0.12);
+  overflow: hidden;
+  animation: rise-in 360ms ease-out;
+}
+
+.hero-body {
+  padding: clamp(1.1rem, 3vw, 2rem);
+}
+
+.kicker {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid var(--kicker-line);
+  background: var(--kicker-bg);
+  color: var(--kicker-ink);
+  padding: 0.36rem 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.hero h1 {
+  margin: 0.7rem 0 0.55rem;
+  font-family: "Fraunces", "Georgia", serif;
+  font-size: clamp(2rem, 5vw, 3.3rem);
+  line-height: 1.03;
+  letter-spacing: -0.012em;
+}
+
+.hero p {
+  margin: 0;
+  max-width: 70ch;
+  color: var(--ink-700);
+}
+
+.hero-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.62rem;
+  margin-top: 1.1rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  border: 1px solid var(--line-300);
+  background: #ffffff;
+  color: var(--ink-900);
+  padding: 0.62rem 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn-primary {
+  color: #ffffff;
+  border-color: var(--leaf-strong);
+  background: linear-gradient(180deg, var(--primary-grad-top), var(--primary-grad-bottom));
+}
+
+.btn-ghost {
+  background: rgba(255, 255, 255, 0.54);
+}
+
+.section {
+  margin-top: 0.85rem;
+  border: 1px solid var(--line-300);
+  border-radius: 18px;
+  background: var(--paper);
+  box-shadow: 0 12px 28px rgba(16, 33, 51, 0.08);
+  padding: clamp(1rem, 2.2vw, 1.4rem);
+}
+
+.section h2 {
+  margin: 0 0 0.7rem;
+  font-family: "Fraunces", "Georgia", serif;
+  font-size: clamp(1.4rem, 2.7vw, 1.95rem);
+  line-height: 1.06;
+}
+
+.section .subtle {
+  margin: 0;
+  color: var(--ink-700);
+}
+
+.grid-3,
+.grid-2 {
+  display: grid;
+  gap: 0.68rem;
+  margin-top: 0.8rem;
+}
+
+.grid-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.grid-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.card {
+  border: 1px solid var(--line-200);
+  border-radius: 14px;
+  background:
+    radial-gradient(90% 120% at 100% 0%, rgba(227, 240, 255, 0.56), transparent),
+    #ffffff;
+  padding: 0.9rem;
+}
+
+.card h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1.02rem;
+}
+
+.card p {
+  margin: 0;
+  color: var(--ink-700);
+  font-size: 0.95rem;
+}
+
+.loop-step {
+  display: flex;
+  gap: 0.62rem;
+}
+
+.loop-step strong {
+  width: 1.6rem;
+  height: 1.6rem;
+  flex-shrink: 0;
+  border-radius: 999px;
+  border: 1px solid var(--loop-dot-line);
+  background: var(--mint);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.82rem;
+  color: var(--loop-dot-ink);
+}
+
+.panel {
+  border: 1px solid var(--line-200);
+  border-radius: 14px;
+  background: #ffffff;
+  padding: 0.86rem;
+}
+
+.panel h3 {
+  margin: 0 0 0.34rem;
+  font-size: 1rem;
+}
+
+.panel p {
+  margin: 0;
+  color: var(--ink-700);
+}
+
+.fine-print {
+  margin-top: 0.72rem;
+  border-left: 3px solid #df8d53;
+  background: var(--warn-bg);
+  color: var(--warn-ink);
+  padding: 0.58rem 0.68rem;
+  border-radius: 8px;
+}
+
+.kv-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.62rem;
+}
+
+.kv {
+  border: 1px solid var(--line-200);
+  border-radius: 12px;
+  background: #ffffff;
+  padding: 0.7rem;
+}
+
+.kv .k {
+  font-size: 0.72rem;
+  color: var(--ink-500);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.kv .v {
+  margin-top: 0.36rem;
+  font-size: 1rem;
+  word-break: break-word;
+}
+
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.62rem;
+  margin-top: 0.72rem;
+}
+
+.metric {
+  border: 1px solid var(--line-200);
+  border-radius: 13px;
+  background: #ffffff;
+  padding: 0.72rem;
+}
+
+.metric .name {
+  font-size: 0.74rem;
+  color: var(--ink-500);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.metric .value {
+  margin-top: 0.32rem;
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.mono {
+  font-family: "IBM Plex Mono", "Menlo", monospace;
+}
+
+.table-wrap {
+  margin-top: 0.68rem;
+  border: 1px solid var(--line-200);
+  border-radius: 12px;
+  overflow: auto;
+  background: #ffffff;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+th,
+td {
+  text-align: left;
+  border-top: 1px solid var(--line-200);
+  padding: 0.58rem 0.62rem;
+  font-size: 0.91rem;
+  vertical-align: top;
+}
+
+th {
+  border-top: none;
+  background: var(--mist);
+  font-size: 0.73rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.68rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.field {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.field label {
+  font-size: 0.84rem;
+  color: var(--ink-700);
+}
+
+.field input,
+.field select,
+.field textarea {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid var(--line-300);
+  background: #ffffff;
+  color: var(--ink-900);
+  font: inherit;
+  padding: 0.56rem 0.62rem;
+}
+
+.field textarea {
+  min-height: 84px;
+  resize: vertical;
+}
+
+.field.full {
+  grid-column: 1 / -1;
+}
+
+.chip-set {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border-radius: 999px;
+  border: 1px solid var(--line-300);
+  background: #ffffff;
+  padding: 0.38rem 0.58rem;
+  font-size: 0.84rem;
+}
+
+.chip input {
+  margin: 0;
+}
+
+.checkline {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.45rem;
+}
+
+.message {
+  margin-top: 0.7rem;
+  border-radius: 10px;
+  border: 1px solid var(--message-line);
+  background: var(--message-bg);
+  color: var(--message-ink);
+  padding: 0.62rem 0.7rem;
+}
+
+.footer-note {
+  margin-top: 1rem;
+  color: var(--ink-500);
+  font-size: 0.85rem;
+}
+
+@keyframes rise-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 900px) {
+  .grid-3,
+  .grid-2,
+  .metric-row,
+  .form-grid,
+  .kv-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .top-nav {
+    position: static;
+  }
+}

--- a/docs/listing-gtm/web/assets/regen-campaign.js
+++ b/docs/listing-gtm/web/assets/regen-campaign.js
@@ -1,0 +1,219 @@
+const SUPPORTER_STORAGE_KEY = "regen_listing_supporter_profile_v1";
+const PROOF_STORAGE_KEY = "regen_listing_local_proofs_v1";
+const BRAND_STORAGE_KEY = "regen_listing_brand_mode_v1";
+
+const BRAND_COPY = {
+  regen: {
+    stackName: "Regen AI Supporter Stack",
+  },
+  bridge: {
+    stackName: "Bridge.eco Supporter Stack",
+  },
+};
+
+function safeJsonParse(input, fallback) {
+  try {
+    return JSON.parse(input);
+  } catch {
+    return fallback;
+  }
+}
+
+function slug(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function normalizeBrand(raw) {
+  const value = String(raw || "").trim().toLowerCase();
+  if (!value) return "regen";
+  if (value === "bridge" || value === "bridge.eco" || value.startsWith("bridge")) {
+    return "bridge";
+  }
+  return "regen";
+}
+
+function getStoredBrand() {
+  try {
+    return normalizeBrand(localStorage.getItem(BRAND_STORAGE_KEY));
+  } catch {
+    return "regen";
+  }
+}
+
+function setStoredBrand(brand) {
+  try {
+    localStorage.setItem(BRAND_STORAGE_KEY, normalizeBrand(brand));
+  } catch {
+    // no-op
+  }
+}
+
+function getBrandFromQuery() {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const brand = params.get("brand");
+    return brand ? normalizeBrand(brand) : null;
+  } catch {
+    return null;
+  }
+}
+
+function detectBrand() {
+  const fromQuery = getBrandFromQuery();
+  if (fromQuery) {
+    setStoredBrand(fromQuery);
+    return fromQuery;
+  }
+
+  return getStoredBrand();
+}
+
+function applyBrandText(brand) {
+  const copy = BRAND_COPY[normalizeBrand(brand)] || BRAND_COPY.regen;
+  document.querySelectorAll("[data-brand-text]").forEach((node) => {
+    const key = node.getAttribute("data-brand-text");
+    if (!key || !copy[key]) return;
+    node.textContent = copy[key];
+  });
+}
+
+function decorateRelativeLinks(brand) {
+  document.querySelectorAll("a[href]").forEach((link) => {
+    const raw = link.getAttribute("href") || "";
+    if (!raw.startsWith("./")) return;
+    if (!raw.includes(".html")) return;
+    if (raw.includes("brand=")) return;
+
+    const [pathWithQuery, hashPart] = raw.split("#");
+    const joiner = pathWithQuery.includes("?") ? "&" : "?";
+    const next = `${pathWithQuery}${joiner}brand=${encodeURIComponent(brand)}${
+      hashPart ? `#${hashPart}` : ""
+    }`;
+    link.setAttribute("href", next);
+  });
+}
+
+function applyBrand() {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return "regen";
+  }
+
+  const brand = detectBrand();
+  document.body.setAttribute("data-brand", brand);
+  applyBrandText(brand);
+  decorateRelativeLinks(brand);
+  return brand;
+}
+
+function makeSupporterId(name, identityRef) {
+  const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+  const left = slug(name).slice(0, 10) || "supporter";
+  const right = slug(identityRef).slice(0, 8) || "community";
+  return `rg-${left}-${right}-${stamp}`;
+}
+
+function loadSupporterProfile() {
+  const raw = localStorage.getItem(SUPPORTER_STORAGE_KEY);
+  return raw ? safeJsonParse(raw, null) : null;
+}
+
+function saveSupporterProfile(profile) {
+  localStorage.setItem(SUPPORTER_STORAGE_KEY, JSON.stringify(profile));
+}
+
+function loadLocalProofs() {
+  const raw = localStorage.getItem(PROOF_STORAGE_KEY);
+  const parsed = raw ? safeJsonParse(raw, []) : [];
+  return Array.isArray(parsed) ? parsed : [];
+}
+
+function saveLocalProofs(items) {
+  localStorage.setItem(PROOF_STORAGE_KEY, JSON.stringify(items));
+}
+
+function appendLocalProof(item) {
+  const entries = loadLocalProofs();
+  entries.unshift(item);
+  saveLocalProofs(entries.slice(0, 50));
+}
+
+function formatIsoDate(iso) {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString();
+}
+
+async function copyText(text) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const helper = document.createElement("textarea");
+  helper.value = text;
+  document.body.appendChild(helper);
+  helper.select();
+  document.execCommand("copy");
+  helper.remove();
+}
+
+function downloadJson(filename, data) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+function buildSupporterPost(profile) {
+  const focus = (profile.stewardshipFocus || []).join(", ") || "mixed";
+  const walletRef = profile.walletReference || "none";
+  const email = profile.contactEmail || "none";
+  const telegram = profile.telegramHandle || "none";
+  return [
+    "#supporter-optin",
+    `supporter_id: ${profile.supporterId}`,
+    `participation_mode: ${profile.participationMode}`,
+    `offset_path: ${profile.offsetPath}`,
+    `telegram: ${telegram}`,
+    `contact_email: ${email}`,
+    `wallet_reference: ${walletRef}`,
+    `horizon_months: ${profile.holdingHorizonMonths}`,
+    `monthly_regen_usd: ${profile.monthlyRegenUsd}`,
+    `ai_prompt_cadence: ${profile.aiPromptCadence}`,
+    `local_ecosystem: ${profile.localEcosystem}`,
+    `stewardship_focus: ${focus}`,
+  ].join("\n");
+}
+
+function buildProofPost(entry, supporterId) {
+  return [
+    "#proof",
+    `supporter_id: ${supporterId || "unknown"}`,
+    `retirement_id: ${entry.retirementId}`,
+    `tx_hash: ${entry.txHash}`,
+    `certificate_url: ${entry.certificateUrl}`,
+    `note: ${entry.note || "proof submission"}`,
+  ].join("\n");
+}
+
+window.RegenCampaign = {
+  applyBrand,
+  makeSupporterId,
+  loadSupporterProfile,
+  saveSupporterProfile,
+  loadLocalProofs,
+  appendLocalProof,
+  formatIsoDate,
+  copyText,
+  downloadJson,
+  buildSupporterPost,
+  buildProofPost,
+};

--- a/docs/listing-gtm/web/listing-landing.html
+++ b/docs/listing-gtm/web/listing-landing.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Regenerative AI Supporter Launch</title>
+    <meta
+      name="description"
+      content="Sync token participation with AI prompting and verifiable regeneration outcomes."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=IBM+Plex+Mono:wght@400;500&family=Sora:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./assets/regen-campaign.css" />
+  </head>
+  <body>
+    <main class="page-shell">
+      <header class="top-nav">
+        <a class="brand" href="./listing-landing.html">
+          <span class="brand-dot"></span>
+          <span data-brand-text="stackName">Regen AI Supporter Stack</span>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a class="nav-link is-active" href="./listing-landing.html">Landing</a>
+          <a class="nav-link" href="./supporter-opt-in.html">Supporter Opt-In</a>
+          <a class="nav-link" href="./proof-page.html">Proof Board</a>
+          <a class="nav-link" href="./supporter-opt-in.html#campaign-rules">Rules</a>
+        </nav>
+      </header>
+
+      <section class="hero">
+        <div class="hero-body">
+          <span class="kicker">Listing Campaign</span>
+          <h1>Sync your token conviction with every AI prompt.</h1>
+          <p>
+            This campaign is built for retail traders who want a long-term role in
+            regenerative AI. Buy access on exchange, or opt in as a non-holder supporter,
+            then verify ecological outcomes with public proof.
+          </p>
+          <div class="hero-cta-row">
+            <a
+              class="btn btn-primary"
+              href="https://www.coinstore.com/home"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Trade on Coinstore
+            </a>
+            <a class="btn" href="./supporter-opt-in.html">
+              Become a Long-Term Supporter
+            </a>
+            <a class="btn btn-ghost" href="./proof-page.html">View Proof Board</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>The Sync Loop</h2>
+        <p class="subtle">
+          The goal is not one-day volume. The goal is recurring alignment between
+          investment behavior, AI usage, and verifiable regeneration.
+        </p>
+        <div class="grid-2">
+          <article class="card loop-step">
+            <strong>1</strong>
+            <div>
+              <h3>Take Position</h3>
+              <p>Access the token through the listing venue and set your support horizon.</p>
+            </div>
+          </article>
+          <article class="card loop-step">
+            <strong>2</strong>
+            <div>
+              <h3>Prompt with Intent</h3>
+              <p>Pair AI prompting activity with a monthly regeneration commitment.</p>
+            </div>
+          </article>
+          <article class="card loop-step">
+            <strong>3</strong>
+            <div>
+              <h3>Anchor to Stewardship</h3>
+              <p>Select local ecosystem context like watershed, forest edge, soil, or coast.</p>
+            </div>
+          </article>
+          <article class="card loop-step">
+            <strong>4</strong>
+            <div>
+              <h3>Verify Publicly</h3>
+              <p>Publish tx hash and certificate references so the community can verify outcomes.</p>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Retail Supporter Design</h2>
+        <div class="grid-3">
+          <article class="panel">
+            <h3>Long-Term by Default</h3>
+            <p>
+              Supporters choose a holding horizon and contribution rhythm to reduce
+              short-cycle behavior.
+            </p>
+          </article>
+          <article class="panel">
+            <h3>Local Context Included</h3>
+            <p>
+              Every supporter can record local stewardship context, connecting global
+              AI use with place-based ecological priorities.
+            </p>
+          </article>
+          <article class="panel">
+            <h3>Proof-Driven Culture</h3>
+            <p>
+              Campaign status is based on verified submissions and certificates, not
+              narrative alone.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>What to Do Right Now</h2>
+        <div class="grid-2">
+          <article class="panel">
+            <h3>Step A: Opt In</h3>
+            <p>
+              Fill supporter profile with AI cadence, holding horizon, and local ecosystem context.
+            </p>
+            <p><a href="./supporter-opt-in.html">Open supporter opt-in page</a></p>
+          </article>
+          <article class="panel">
+            <h3>Step B: Submit Proof</h3>
+            <p>
+              After completing a qualified action, submit proof entries and keep your
+              participation trackable.
+            </p>
+            <p><a href="./proof-page.html">Open proof board</a></p>
+          </article>
+        </div>
+        <p class="fine-print">
+          This page is informational. No return guarantees or investment promises are
+          made. Participation in digital assets carries risk.
+        </p>
+      </section>
+
+      <p class="footer-note">
+        Campaign stack: landing -> supporter opt-in -> proof board.
+      </p>
+    </main>
+    <script src="./assets/regen-campaign.js"></script>
+    <script>
+      window.RegenCampaign.applyBrand();
+    </script>
+  </body>
+</html>

--- a/docs/listing-gtm/web/proof-feed.json
+++ b/docs/listing-gtm/web/proof-feed.json
@@ -1,0 +1,31 @@
+{
+  "updated_at": "2026-02-24T12:00:00Z",
+  "totals": {
+    "retirements": 3,
+    "credits_retired": "14.320000",
+    "supporters_opted_in": 27
+  },
+  "recent_retirements": [
+    {
+      "date": "2026-02-24",
+      "retirement_id": "WyLaunch001",
+      "tx_hash": "ABC123-LAUNCH-TX",
+      "certificate_url": "https://regen.network/certificate/sample-001",
+      "notes": "Listing day pooled retirement"
+    },
+    {
+      "date": "2026-02-23",
+      "retirement_id": "WyLaunch000",
+      "tx_hash": "ABC122-PRELAUNCH",
+      "certificate_url": "https://regen.network/certificate/sample-000",
+      "notes": "Pre-launch rehearsal batch"
+    },
+    {
+      "date": "2026-02-22",
+      "retirement_id": "WyPilot199",
+      "tx_hash": "ABC121-PILOT",
+      "certificate_url": "https://regen.network/certificate/sample-199",
+      "notes": "Pilot run verification"
+    }
+  ]
+}

--- a/docs/listing-gtm/web/proof-page.html
+++ b/docs/listing-gtm/web/proof-page.html
@@ -1,0 +1,320 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Regenerative AI Proof Board</title>
+    <meta
+      name="description"
+      content="Public proof board for regeneration-linked participation and supporter verification."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=IBM+Plex+Mono:wght@400;500&family=Sora:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./assets/regen-campaign.css" />
+  </head>
+  <body>
+    <main class="page-shell">
+      <header class="top-nav">
+        <a class="brand" href="./listing-landing.html">
+          <span class="brand-dot"></span>
+          <span data-brand-text="stackName">Regen AI Supporter Stack</span>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a class="nav-link" href="./listing-landing.html">Landing</a>
+          <a class="nav-link" href="./supporter-opt-in.html">Supporter Opt-In</a>
+          <a class="nav-link is-active" href="./proof-page.html">Proof Board</a>
+          <a class="nav-link" href="./supporter-opt-in.html#campaign-rules">Rules</a>
+        </nav>
+      </header>
+
+      <section class="hero">
+        <div class="hero-body">
+          <span class="kicker">Verification Layer</span>
+          <h1>Proof over hype.</h1>
+          <p>
+            This board tracks regeneration actions and supporter participation evidence.
+            Use it as the primary reference for campaign credibility.
+          </p>
+          <div class="hero-cta-row">
+            <a class="btn" href="./supporter-opt-in.html">Submit Supporter Opt-In</a>
+            <a
+              class="btn btn-primary"
+              href="https://www.coinstore.com/home"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Open Coinstore
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Campaign Metrics</h2>
+        <div class="metric-row">
+          <article class="metric">
+            <div class="name">Total Retirements</div>
+            <div class="value" id="metric-retirements">0</div>
+          </article>
+          <article class="metric">
+            <div class="name">Credits Retired</div>
+            <div class="value" id="metric-credits">0.000000</div>
+          </article>
+          <article class="metric">
+            <div class="name">Opted-In Supporters</div>
+            <div class="value" id="metric-supporters">0</div>
+          </article>
+        </div>
+        <p class="footer-note">
+          Last feed update: <span id="feed-updated-at" class="mono">-</span>
+        </p>
+      </section>
+
+      <section class="section">
+        <h2>Verified Retirement Feed</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Retirement ID</th>
+                <th>Tx Hash</th>
+                <th>Certificate</th>
+                <th>Notes</th>
+              </tr>
+            </thead>
+            <tbody id="retirement-rows"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Local Proof Submissions (Operator Cache)</h2>
+        <p class="subtle">
+          This section stores quick submissions in local browser storage during live ops.
+          It is useful for triage before final indexing.
+        </p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Submitted</th>
+                <th>Retirement ID</th>
+                <th>Tx Hash</th>
+                <th>Certificate URL</th>
+                <th>Note</th>
+              </tr>
+            </thead>
+            <tbody id="local-proof-rows"></tbody>
+          </table>
+        </div>
+
+        <form id="proof-form" class="form-grid" style="margin-top: 0.75rem;">
+          <div class="field">
+            <label for="retirement_id">Retirement ID</label>
+            <input id="retirement_id" name="retirement_id" required />
+          </div>
+          <div class="field">
+            <label for="tx_hash">Tx Hash</label>
+            <input id="tx_hash" name="tx_hash" required />
+          </div>
+          <div class="field full">
+            <label for="certificate_url">Certificate URL</label>
+            <input
+              id="certificate_url"
+              name="certificate_url"
+              type="url"
+              placeholder="https://regen.network/certificate/..."
+              required
+            />
+          </div>
+          <div class="field full">
+            <label for="proof_note">Note</label>
+            <textarea
+              id="proof_note"
+              name="proof_note"
+              placeholder="Optional context, e.g., listing-day retirement batch"
+            ></textarea>
+          </div>
+          <div class="field full">
+            <div class="hero-cta-row">
+              <button class="btn btn-primary" type="submit">Save Local Proof</button>
+              <button class="btn" type="button" id="copy-proof-btn">Copy #proof Block</button>
+            </div>
+          </div>
+        </form>
+        <div id="proof-message"></div>
+      </section>
+
+      <p class="footer-note">
+        Verification routine: open certificate, cross-check tx hash, confirm date and note.
+      </p>
+    </main>
+
+    <script src="./assets/regen-campaign.js"></script>
+    <script>
+      window.RegenCampaign.applyBrand();
+
+      const fallbackFeed = {
+        updated_at: "2026-02-24T12:00:00Z",
+        totals: {
+          retirements: 3,
+          credits_retired: "14.320000",
+          supporters_opted_in: 27
+        },
+        recent_retirements: [
+          {
+            date: "2026-02-24",
+            retirement_id: "WyLaunch001",
+            tx_hash: "ABC123-LAUNCH-TX",
+            certificate_url: "https://regen.network/certificate/sample-001",
+            notes: "Listing day pooled retirement"
+          },
+          {
+            date: "2026-02-23",
+            retirement_id: "WyLaunch000",
+            tx_hash: "ABC122-PRELAUNCH",
+            certificate_url: "https://regen.network/certificate/sample-000",
+            notes: "Pre-launch rehearsal batch"
+          },
+          {
+            date: "2026-02-22",
+            retirement_id: "WyPilot199",
+            tx_hash: "ABC121-PILOT",
+            certificate_url: "https://regen.network/certificate/sample-199",
+            notes: "Pilot run verification"
+          }
+        ]
+      };
+
+      async function loadFeed() {
+        try {
+          const response = await fetch("./proof-feed.json", { cache: "no-store" });
+          if (!response.ok) throw new Error("proof-feed.json not found");
+          return await response.json();
+        } catch {
+          return fallbackFeed;
+        }
+      }
+
+      function renderRetirementRows(feed) {
+        const rows = document.getElementById("retirement-rows");
+        rows.innerHTML = (feed.recent_retirements || [])
+          .map((item) => {
+            return `
+              <tr>
+                <td>${item.date || "-"}</td>
+                <td class="mono">${item.retirement_id || "-"}</td>
+                <td class="mono">${item.tx_hash || "-"}</td>
+                <td><a href="${item.certificate_url || "#"}" target="_blank" rel="noreferrer">open</a></td>
+                <td>${item.notes || ""}</td>
+              </tr>
+            `;
+          })
+          .join("");
+      }
+
+      function renderLocalProofs() {
+        const entries = window.RegenCampaign.loadLocalProofs();
+        const rows = document.getElementById("local-proof-rows");
+
+        if (!entries.length) {
+          rows.innerHTML = `
+            <tr>
+              <td colspan="5">No local proof submissions yet.</td>
+            </tr>
+          `;
+          return;
+        }
+
+        rows.innerHTML = entries
+          .map((item) => {
+            return `
+              <tr>
+                <td>${window.RegenCampaign.formatIsoDate(item.createdAt)}</td>
+                <td class="mono">${item.retirementId}</td>
+                <td class="mono">${item.txHash}</td>
+                <td><a href="${item.certificateUrl}" target="_blank" rel="noreferrer">open</a></td>
+                <td>${item.note || ""}</td>
+              </tr>
+            `;
+          })
+          .join("");
+      }
+
+      async function renderFeed() {
+        const feed = await loadFeed();
+        const supporterProfile = window.RegenCampaign.loadSupporterProfile();
+
+        document.getElementById("metric-retirements").textContent = String(
+          feed?.totals?.retirements || 0
+        );
+        document.getElementById("metric-credits").textContent =
+          feed?.totals?.credits_retired || "0.000000";
+
+        const supporterCountFromFeed = Number(feed?.totals?.supporters_opted_in || 0);
+        const supporterCount = supporterProfile
+          ? Math.max(1, supporterCountFromFeed)
+          : supporterCountFromFeed;
+        document.getElementById("metric-supporters").textContent = String(supporterCount);
+
+        document.getElementById("feed-updated-at").textContent =
+          window.RegenCampaign.formatIsoDate(feed.updated_at || "");
+        renderRetirementRows(feed);
+        renderLocalProofs();
+      }
+
+      function setMessage(text) {
+        const target = document.getElementById("proof-message");
+        target.className = "message";
+        target.textContent = text;
+      }
+
+      function setupProofForm() {
+        const form = document.getElementById("proof-form");
+        const copyProofBtn = document.getElementById("copy-proof-btn");
+        const supporter = window.RegenCampaign.loadSupporterProfile();
+        let lastEntry = null;
+
+        form.addEventListener("submit", (event) => {
+          event.preventDefault();
+          const formData = new FormData(form);
+          const entry = {
+            createdAt: new Date().toISOString(),
+            retirementId: String(formData.get("retirement_id") || "").trim(),
+            txHash: String(formData.get("tx_hash") || "").trim(),
+            certificateUrl: String(formData.get("certificate_url") || "").trim(),
+            note: String(formData.get("proof_note") || "").trim(),
+          };
+
+          window.RegenCampaign.appendLocalProof(entry);
+          lastEntry = entry;
+          renderLocalProofs();
+          form.reset();
+          setMessage("Local proof saved. You can now copy a #proof block for Telegram.");
+        });
+
+        copyProofBtn.addEventListener("click", async () => {
+          if (!lastEntry) {
+            setMessage("Save a proof entry first, then copy the #proof block.");
+            return;
+          }
+
+          const block = window.RegenCampaign.buildProofPost(
+            lastEntry,
+            supporter?.supporterId
+          );
+          await window.RegenCampaign.copyText(block);
+          setMessage("Copied #proof block to clipboard.");
+        });
+      }
+
+      renderFeed();
+      setupProofForm();
+    </script>
+  </body>
+</html>

--- a/docs/listing-gtm/web/supporter-opt-in.html
+++ b/docs/listing-gtm/web/supporter-opt-in.html
@@ -1,0 +1,457 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Supporter Opt-In | Regenerative AI</title>
+    <meta
+      name="description"
+      content="Anyone can opt in as a long-term supporter: align token or non-token AI prompting with regeneration stewardship."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=IBM+Plex+Mono:wght@400;500&family=Sora:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./assets/regen-campaign.css" />
+  </head>
+  <body>
+    <main class="page-shell">
+      <header class="top-nav">
+        <a class="brand" href="./listing-landing.html">
+          <span class="brand-dot"></span>
+          <span data-brand-text="stackName">Regen AI Supporter Stack</span>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a class="nav-link" href="./listing-landing.html">Landing</a>
+          <a class="nav-link is-active" href="./supporter-opt-in.html">Supporter Opt-In</a>
+          <a class="nav-link" href="./proof-page.html">Proof Board</a>
+          <a class="nav-link" href="#campaign-rules">Rules</a>
+        </nav>
+      </header>
+
+      <section class="hero">
+        <div class="hero-body">
+          <span class="kicker">Long-Term Supporter Intake</span>
+          <h1>Opt in with intent, not just entry timing.</h1>
+          <p>
+            Anyone can opt in, including non-holders. This form captures your support profile:
+            participation mode, AI prompt cadence, and local ecosystem context. After submission,
+            copy your opt-in block for community proof.
+          </p>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Open Opt-In Paths</h2>
+        <div class="grid-3">
+          <article class="panel">
+            <h3>Holder Path</h3>
+            <p>Hold token and attach support behavior to ongoing AI prompting.</p>
+          </article>
+          <article class="panel">
+            <h3>Non-Holder Path</h3>
+            <p>No token required. Join as a contributor and submit verifiable proof actions.</p>
+          </article>
+          <article class="panel">
+            <h3>Hybrid Path</h3>
+            <p>Combine token alignment with direct recurring regeneration support.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Supporter Profile</h2>
+        <form id="supporter-form" class="form-grid">
+          <div class="field">
+            <label for="supporter_name">Display Name</label>
+            <input id="supporter_name" name="supporter_name" required />
+          </div>
+          <div class="field">
+            <label for="telegram_handle">Telegram Handle</label>
+            <input
+              id="telegram_handle"
+              name="telegram_handle"
+              placeholder="@yourhandle"
+            />
+          </div>
+          <div class="field">
+            <label for="contact_email">Contact Email</label>
+            <input
+              id="contact_email"
+              name="contact_email"
+              type="email"
+              placeholder="name@example.com"
+            />
+          </div>
+          <div class="field">
+            <label for="wallet_reference">Wallet or Exchange Reference (optional)</label>
+            <input
+              id="wallet_reference"
+              name="wallet_reference"
+              placeholder="wallet address or exchange UID"
+            />
+          </div>
+          <div class="field">
+            <label for="participation_mode">Participation Mode</label>
+            <select id="participation_mode" name="participation_mode" required>
+              <option value="holder">Holder</option>
+              <option value="supporter_no_token">Non-holder supporter</option>
+              <option value="hybrid" selected>Hybrid</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="offset_path">Offset/Contribution Path</label>
+            <select id="offset_path" name="offset_path" required>
+              <option value="token_aligned">Token-aligned participation</option>
+              <option value="direct_contribution">Direct recurring contribution</option>
+              <option value="pooled_membership" selected>Pooled membership contribution</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="holding_horizon_months">Holding Horizon</label>
+            <select id="holding_horizon_months" name="holding_horizon_months" required>
+              <option value="3">3 months</option>
+              <option value="6">6 months</option>
+              <option value="12" selected>12 months</option>
+              <option value="24">24 months</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="ai_prompt_cadence">AI Prompt Cadence</label>
+            <select id="ai_prompt_cadence" name="ai_prompt_cadence" required>
+              <option value="light">Light (1-3 sessions/week)</option>
+              <option value="active" selected>Active (4-7 sessions/week)</option>
+              <option value="intense">Intense (daily, high volume)</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="monthly_regen_usd">Monthly Regeneration Support (USD)</label>
+            <select id="monthly_regen_usd" name="monthly_regen_usd" required>
+              <option value="1">$1</option>
+              <option value="3">$3</option>
+              <option value="5" selected>$5</option>
+              <option value="10">$10</option>
+              <option value="25">$25+</option>
+            </select>
+          </div>
+          <div class="field full">
+            <label for="local_ecosystem">
+              Local Ecosystem Context
+            </label>
+            <input
+              id="local_ecosystem"
+              name="local_ecosystem"
+              placeholder="e.g., Cascadia watershed, Yucatan forest corridor, local mangrove coast"
+              required
+            />
+          </div>
+          <div class="field full">
+            <label>Nature Stewardship Focus</label>
+            <div class="chip-set">
+              <label class="chip"><input type="checkbox" name="focus" value="soil" />Soil</label>
+              <label class="chip"><input type="checkbox" name="focus" value="watershed" />Watershed</label>
+              <label class="chip"><input type="checkbox" name="focus" value="forest" />Forest</label>
+              <label class="chip"><input type="checkbox" name="focus" value="coastal" />Coastal</label>
+              <label class="chip"><input type="checkbox" name="focus" value="biodiversity" />Biodiversity</label>
+            </div>
+          </div>
+          <div class="field full">
+            <label for="supporter_notes">Optional Notes</label>
+            <textarea
+              id="supporter_notes"
+              name="supporter_notes"
+              placeholder="What does long-term regenerative support mean in your context?"
+            ></textarea>
+          </div>
+          <div class="field full">
+            <label class="checkline">
+              <input type="checkbox" id="commit_hold" required />
+              <span>I commit to maintain my selected support horizon (holding or contribution).</span>
+            </label>
+            <label class="checkline">
+              <input type="checkbox" id="commit_proof" required />
+              <span>I commit to submit verifiable proof entries during campaign windows.</span>
+            </label>
+            <p class="subtle">
+              Minimum contact requirement: provide Telegram handle or contact email.
+            </p>
+          </div>
+          <div class="field full">
+            <div class="hero-cta-row">
+              <button class="btn btn-primary" type="submit">Save Supporter Profile</button>
+              <button class="btn" type="button" id="copy-optin-btn">Copy #supporter-optin</button>
+              <button class="btn" type="button" id="download-profile-btn">Download JSON</button>
+            </div>
+          </div>
+        </form>
+        <div id="form-message"></div>
+      </section>
+
+      <section class="section">
+        <h2>Current Profile Snapshot</h2>
+        <div class="kv-grid" id="profile-snapshot">
+          <article class="kv">
+            <div class="k">Supporter ID</div>
+            <div class="v mono" id="snapshot-supporter-id">-</div>
+          </article>
+          <article class="kv">
+            <div class="k">Telegram</div>
+            <div class="v" id="snapshot-telegram">-</div>
+          </article>
+          <article class="kv">
+            <div class="k">Contact Email</div>
+            <div class="v" id="snapshot-email">-</div>
+          </article>
+          <article class="kv">
+            <div class="k">Participation Mode</div>
+            <div class="v" id="snapshot-mode">-</div>
+          </article>
+          <article class="kv">
+            <div class="k">Offset Path</div>
+            <div class="v" id="snapshot-offset">-</div>
+          </article>
+          <article class="kv">
+            <div class="k">Wallet/Exchange Ref</div>
+            <div class="v mono" id="snapshot-identity">-</div>
+          </article>
+          <article class="kv">
+            <div class="k">Holding Horizon</div>
+            <div class="v" id="snapshot-horizon">-</div>
+          </article>
+          <article class="kv">
+            <div class="k">Monthly Support</div>
+            <div class="v" id="snapshot-support">-</div>
+          </article>
+          <article class="kv">
+            <div class="k">AI Cadence</div>
+            <div class="v" id="snapshot-cadence">-</div>
+          </article>
+          <article class="kv">
+            <div class="k">Local Ecosystem Context</div>
+            <div class="v" id="snapshot-local">-</div>
+          </article>
+        </div>
+        <div class="hero-cta-row" style="margin-top: 0.72rem;">
+          <a class="btn" href="./proof-page.html">Go to Proof Board</a>
+          <a
+            class="btn btn-primary"
+            href="https://www.coinstore.com/home"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Trade on Coinstore
+          </a>
+        </div>
+        <p class="fine-print">
+          Supporter opt-in is a participation pledge, not a return contract. No financial
+          guarantees are implied by this form.
+        </p>
+      </section>
+
+      <section class="section" id="campaign-rules">
+        <h2>Campaign Rules (Supporter Cycle)</h2>
+        <div class="grid-2">
+          <article class="panel">
+            <h3>Eligibility</h3>
+            <p>
+              1) Anyone can complete opt-in profile (holder or non-holder). 2) Complete one
+              qualified participation action. 3) Submit proof block with valid tx hash and
+              certificate URL.
+            </p>
+          </article>
+          <article class="panel">
+            <h3>Verification Standard</h3>
+            <p>
+              Proof must be publicly checkable. Duplicate artifacts or unverifiable references
+              are not eligible.
+            </p>
+          </article>
+          <article class="panel">
+            <h3>Conduct and Safety</h3>
+            <p>
+              No price promises, no financial advice, no private-key requests. Use only official links.
+            </p>
+          </article>
+          <article class="panel">
+            <h3>Dispute Handling</h3>
+            <p>
+              Ops team logs disputes daily. Technical lead verifies proof disputes against public records.
+            </p>
+          </article>
+        </div>
+        <div class="table-wrap" style="margin-top: 0.7rem;">
+          <table>
+            <thead>
+              <tr>
+                <th>Submission Block</th>
+                <th>Format</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="mono">#supporter-optin</td>
+                <td class="mono">supporter_id, participation_mode, offset_path, telegram/contact_email, wallet_reference(optional), horizon_months, monthly_regen_usd, ai_prompt_cadence, local_ecosystem, stewardship_focus</td>
+              </tr>
+              <tr>
+                <td class="mono">#proof</td>
+                <td class="mono">supporter_id, retirement_id, tx_hash, certificate_url, note</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <script src="./assets/regen-campaign.js"></script>
+    <script>
+      window.RegenCampaign.applyBrand();
+
+      const form = document.getElementById("supporter-form");
+      const formMessage = document.getElementById("form-message");
+      const copyOptinBtn = document.getElementById("copy-optin-btn");
+      const downloadProfileBtn = document.getElementById("download-profile-btn");
+      const field = (name) => form.elements.namedItem(name);
+      let activeProfile = null;
+
+      function setMessage(text) {
+        formMessage.className = "message";
+        formMessage.textContent = text;
+      }
+
+      function selectedFocusValues() {
+        return Array.from(document.querySelectorAll("input[name='focus']:checked"))
+          .map((node) => node.value);
+      }
+
+      function prefill(profile) {
+        if (!profile) return;
+        field("supporter_name").value = profile.supporterName || "";
+        field("telegram_handle").value = profile.telegramHandle || "";
+        field("contact_email").value = profile.contactEmail || "";
+        field("wallet_reference").value = profile.walletReference || "";
+        field("participation_mode").value = profile.participationMode || "hybrid";
+        field("offset_path").value = profile.offsetPath || "pooled_membership";
+        field("holding_horizon_months").value = String(
+          profile.holdingHorizonMonths || "12"
+        );
+        field("ai_prompt_cadence").value = profile.aiPromptCadence || "active";
+        field("monthly_regen_usd").value = String(profile.monthlyRegenUsd || "5");
+        field("local_ecosystem").value = profile.localEcosystem || "";
+        field("supporter_notes").value = profile.notes || "";
+
+        const focusSet = new Set(profile.stewardshipFocus || []);
+        document.querySelectorAll("input[name='focus']").forEach((node) => {
+          node.checked = focusSet.has(node.value);
+        });
+      }
+
+      function renderSnapshot(profile) {
+        const fallback = "-";
+        document.getElementById("snapshot-supporter-id").textContent =
+          profile?.supporterId || fallback;
+        document.getElementById("snapshot-telegram").textContent =
+          profile?.telegramHandle || fallback;
+        document.getElementById("snapshot-email").textContent =
+          profile?.contactEmail || fallback;
+        document.getElementById("snapshot-mode").textContent =
+          profile?.participationMode || fallback;
+        document.getElementById("snapshot-offset").textContent =
+          profile?.offsetPath || fallback;
+        document.getElementById("snapshot-identity").textContent =
+          profile?.walletReference || fallback;
+        document.getElementById("snapshot-horizon").textContent =
+          profile ? `${profile.holdingHorizonMonths} months` : fallback;
+        document.getElementById("snapshot-support").textContent =
+          profile ? `$${profile.monthlyRegenUsd}` : fallback;
+        document.getElementById("snapshot-cadence").textContent =
+          profile?.aiPromptCadence || fallback;
+        document.getElementById("snapshot-local").textContent =
+          profile?.localEcosystem || fallback;
+      }
+
+      function buildProfileFromForm() {
+        const focus = selectedFocusValues();
+        const supporterName = String(field("supporter_name").value || "").trim();
+        const telegramHandle = String(field("telegram_handle").value || "").trim();
+        const contactEmail = String(field("contact_email").value || "").trim();
+        const walletReference = String(field("wallet_reference").value || "").trim();
+        const participationMode = field("participation_mode").value;
+        const offsetPath = field("offset_path").value;
+        const identityRef = walletReference || contactEmail || telegramHandle || supporterName;
+        const profile = {
+          version: 1,
+          createdAt: new Date().toISOString(),
+          supporterId: window.RegenCampaign.makeSupporterId(supporterName, identityRef),
+          supporterName,
+          participationMode,
+          offsetPath,
+          telegramHandle,
+          contactEmail,
+          walletReference,
+          holdingHorizonMonths: Number(field("holding_horizon_months").value),
+          aiPromptCadence: field("ai_prompt_cadence").value,
+          monthlyRegenUsd: Number(field("monthly_regen_usd").value),
+          localEcosystem: String(field("local_ecosystem").value || "").trim(),
+          stewardshipFocus: focus,
+          notes: String(field("supporter_notes").value || "").trim(),
+        };
+        return profile;
+      }
+
+      form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        const profile = buildProfileFromForm();
+        if (!profile.telegramHandle && !profile.contactEmail) {
+          setMessage("Provide at least one contact method: Telegram handle or email.");
+          return;
+        }
+        if (
+          (profile.participationMode === "holder" || profile.participationMode === "hybrid") &&
+          !profile.walletReference
+        ) {
+          setMessage("Holder/hybrid mode requires wallet or exchange reference.");
+          return;
+        }
+        window.RegenCampaign.saveSupporterProfile(profile);
+        activeProfile = profile;
+        renderSnapshot(profile);
+        setMessage("Supporter profile saved. Copy your #supporter-optin block next.");
+      });
+
+      copyOptinBtn.addEventListener("click", async () => {
+        const profile = activeProfile || window.RegenCampaign.loadSupporterProfile();
+        if (!profile) {
+          setMessage("Save your supporter profile first.");
+          return;
+        }
+        const text = window.RegenCampaign.buildSupporterPost(profile);
+        await window.RegenCampaign.copyText(text);
+        setMessage("Copied #supporter-optin block to clipboard.");
+      });
+
+      downloadProfileBtn.addEventListener("click", () => {
+        const profile = activeProfile || window.RegenCampaign.loadSupporterProfile();
+        if (!profile) {
+          setMessage("Save your supporter profile first.");
+          return;
+        }
+        window.RegenCampaign.downloadJson(
+          `${profile.supporterId || "supporter-profile"}.json`,
+          profile
+        );
+        setMessage("Downloaded supporter profile JSON.");
+      });
+
+      const existing = window.RegenCampaign.loadSupporterProfile();
+      if (existing) {
+        activeProfile = existing;
+        prefill(existing);
+        renderSnapshot(existing);
+      } else {
+        renderSnapshot(null);
+      }
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "start": "node dist/index.js",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
+    "gtm:preflight": "node docs/listing-gtm/scripts/preflight-check.mjs",
+    "gtm:preflight:strict": "node docs/listing-gtm/scripts/preflight-check.mjs --strict-urls",
+    "gtm:bundle": "node docs/listing-gtm/scripts/create-release-bundle.mjs",
     "prepublishOnly": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
# Proposed PR Title

`feat(listing-gtm): Coinstore listing GTM launch stack (landing, supporter opt-in, proof board)`

# PR Body Draft

## PR Context (for humans + agents)

```yaml
pr_context:
  version: 1
  change_type: feat
  scope: listing-gtm/coinstore-launch
  linked_issue: ""
  release_blocking: true
  risk_level: medium
  breaking_change: false
  db_migration: false
  requires_follow_up: true
  owner: TEMP_RELEASE_OWNER
  approver: TEMP_RELEASE_OWNER
  publisher: TEMP_RELEASE_OWNER
```

## Summary
- Adds a 3-page launch web stack for Coinstore listing GTM.
- Introduces supporter opt-in flow that links token and non-token participation to AI prompt cadence and local ecosystem stewardship context.
- Adds proof board flow for retirement/certificate evidence and local proof ops handling.

## Change Set
- Main files/areas touched:
  - `docs/listing-gtm/web/listing-landing.html`
  - `docs/listing-gtm/web/supporter-opt-in.html`
  - `docs/listing-gtm/web/proof-page.html`
  - `docs/listing-gtm/web/proof-feed.json`
  - `docs/listing-gtm/web/assets/regen-campaign.css`
  - `docs/listing-gtm/web/assets/regen-campaign.js`
  - `docs/listing-gtm/templates/*` (Telegram + ops templates)
  - `docs/listing-gtm/scripts/apply-live-urls.mjs`
- User-visible behavior changes:
  - Supporter opt-in profile now supports holder, non-holder, and hybrid modes.
  - Opt-in profile captures long-term commitment and stewardship context.
  - Proof board now supports feed-based metrics and local proof submission cache.
  - Telegram templates now align to `buy -> opt in -> prove`.
- Non-goals:
  - No backend API integration yet.
  - No exchange automation integration in this PR.

## Test Plan
- Commands run:
  - `node --check docs/listing-gtm/web/assets/regen-campaign.js`
- Results:
  - JS syntax check passes.
- Manual checks:
  - [ ] Open each page and validate navigation flow.
  - [ ] Submit supporter profile and confirm local snapshot.
  - [ ] Submit local proof and copy `#proof` block.
  - [ ] Verify proof board reads `proof-feed.json`.

## Risk and Rollback
- Main risks:
  - Static pages can drift from live campaign rules if not updated.
  - Local storage cache is browser-local and not shared.
- Rollback or mitigation:
  - Revert to previous static prototype pages.
  - Keep proof feed updates disciplined via ops log.

## Handoff Notes
- Open follow-ups:
  - Replace placeholder URLs once publishing endpoints are confirmed.
  - Assign permanent owner/approver/publisher after fastlane period.
- Decisions needed:
  - Final hosting destination for web pages.
  - Final rules URL (currently `supporter-opt-in.html#campaign-rules`).
- Deployment/publish steps:
  1. Publish `/docs/listing-gtm/web` directory preserving relative paths.
  2. Run URL replacement script:
     `node docs/listing-gtm/scripts/apply-live-urls.mjs --landing <...> --proof <...> --rules <...>`
  3. Post pinned message + Day 1 Telegram update.

## Checklist
- [ ] Scope is focused and reviewable.
- [ ] Docs updated (if behavior changed).
- [ ] Tests added/updated where appropriate.
- [ ] No secrets or sensitive data included.
- [ ] Owner/Approver/Publisher set in `pr_context`.
