### PR TITLE
Add simple workflow example to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,17 @@ Most MCP clients accept this standard config:
 
 > **ChatGPT and OpenAI API**: These platforms require a remote HTTP MCP server (streamable HTTP or SSE transport). Regenerative Compute currently uses stdio transport. HTTP transport support is on the [roadmap](ROADMAP.md).
 
+## Quick Start
+
+After installing, ask your AI assistant to run these tools:
+
+1. **`estimate_session_footprint`** — See the energy and CO2 cost of your current session
+2. **`browse_available_credits`** — Explore live ecological credits (carbon, biodiversity, marine) on Regen Marketplace
+3. **`retire_credits`** — Retire credits to fund regeneration (credit card link by default, or on-chain with a wallet)
+4. **`get_retirement_certificate`** — Get a verifiable on-chain proof of your contribution
+
+Or just ask: *"Estimate my session's footprint and show me credits I can retire"* — the AI handles the rest.
+
 ## What You Get
 
 | Tool | What it does |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,18 +17,6 @@ The website and the plugin are the same product. They share the same backend, th
 
 This is NOT "carbon offsetting." It's **regenerative contribution** — funding verified ecological regeneration with immutable on-chain proof. No neutrality claims, no greenwashing. Just contribution.
 
-## Simple Example Workflow
-
-Here is how a developer might use Regenerative Compute:
-
-1. Use an AI coding assistant like Claude Code or Cursor
-2. Estimate the environmental footprint of the AI session
-3. Browse available ecological credits from Regen Network
-4. Retire credits that fund ecological regeneration
-5. Receive a verifiable on-chain certificate showing the contribution
-
-This workflow helps developers understand and reduce the ecological impact of their AI usage while supporting real-world regeneration projects.
-
 ## What Already Works (Phase 1.5 — Shipped)
 
 | Tool | What it does |


### PR DESCRIPTION
## Summary
- Adds a "Simple Example Workflow" section to ROADMAP.md
- 5-step explanation of how developers use Regenerative Compute
- Documentation only, no code changes

Cherry-picked from https://github.com/freelancecoding/regen-compute/pull/1 by @freelancecoding