### PR TITLE
Fix email logo: serve PNG for client compatibility

### DIFF
--- a/src/server/brand.ts
+++ b/src/server/brand.ts
@@ -46,6 +46,16 @@ export const regenLogoSVG = `<svg width="186" height="84" viewBox="0 0 186 84" f
 </svg>`;
 
 // ---------------------------------------------------------------------------
+// Regen Network logo PNG (horizontal, black on transparent, 361×162 2x retina)
+// Used in emails — most email clients (Gmail, Outlook) block SVG images.
+// ---------------------------------------------------------------------------
+
+export const regenLogoPNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAWkAAACiCAYAAACDIzyNAAAACXBIWXMAAAsSAAALEgHS3X78AAAZBUlEQVR4nO2d23EbObeF4VP/4SGfpIlAmgjMiUCcCKSJQHQEpiMwHcFoIjAVgaUITEYwUgQjRfCbT1LpRacgL3hgCN3Y6Ebf0OurYnlGZDebfVnY2NiXN8/Pz2osTKazC6XUnVLq6unx4W40P5wQMlhGI9KT6WyplPps/elWKbVRSm2fHh9uOjw0QggpZBQiPZnO5lqMlVIHBR+519a1UuqCFjYhpE9kL9KT6ewQAv1W8PHd0+PDooXDIoQQEf8zgtO0Fgq0Zt7wsRBCSBRZW9KT6exMKfUlcrNf6fIghPSFbC3pyXR2jIXBWI67PXJCCPmXnN0dhyULhWXQJ00I6Q3ZijTC6nYVNqVfmhDSG3JfOFxX2IYiTQjpDWMIwdPhdycx2zw9Prxp7ogIIUTOWELwophMZ/RLE0J6QfYi/fT4sK3gm6bLgxDSC8ZgSasK1jRjpQkhvWA0Ig1r+l76eVTOI4SQThmTJa0irWmKNCGkF4xWpIXWNEWaENILxmJJK+k1Q+U8QgjplNGINGKlL6WfR+U8QgjpEoogIYR0CEWaEEJ6DEWaEEJ6DEWaEEJ6DEWaEEJ6DEWaEEJ6DEWaEEJ6DEWaEEJ6DEWaEEJ6DEWaEEJ6DEWaEEJ6DEWaEEJ6DEWaEEJ6DEWaEEJ6DEWaEEJ6DEWaEEJ6zP8DDK+cWH2f3lcAAAAASUVORK5CYII=",
+  "base64"
+);
+
+// ---------------------------------------------------------------------------
 // Google Fonts link tags
 // ---------------------------------------------------------------------------
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -25,7 +25,7 @@ import { createDashboardRoutes } from "./dashboard.js";
 import { createResearchRoutes } from "./research.js";
 import { createAiPluginRoutes } from "./ai-plugin.js";
 import { loadConfig } from "../config.js";
-import { regenLogoSVG } from "./brand.js";
+import { regenLogoSVG, regenLogoPNG } from "./brand.js";
 
 export function startServer(options: { port?: number; dbPath?: string } = {}) {
   const port = options.port ?? parseInt(process.env.REGEN_SERVER_PORT ?? "3141", 10);
@@ -49,6 +49,13 @@ export function startServer(options: { port?: number; dbPath?: string } = {}) {
     res.setHeader("Content-Type", "image/svg+xml");
     res.setHeader("Cache-Control", "public, max-age=31536000");
     res.send(regenLogoSVG);
+  });
+
+  // Static logo for emails (PNG — compatible with Gmail, Outlook, Apple Mail)
+  app.get("/logo.png", (_req, res) => {
+    res.setHeader("Content-Type", "image/png");
+    res.setHeader("Cache-Control", "public, max-age=31536000");
+    res.send(regenLogoPNG);
   });
 
   // OG image for social media previews

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -24,8 +24,8 @@ import type { PoolRunResult, CreditTypeResult } from "./pool.js";
 
 const POSTMARK_API_URL = "https://api.postmarkapp.com/email";
 
-// Regen Network logo served from our own server (email clients need a real image URL)
-const REGEN_LOGO_URL = "https://compute.regen.network/logo.svg";
+// PNG logo — Gmail, Outlook, and most email clients block SVG images
+const REGEN_LOGO_URL = "https://compute.regen.network/logo.png";
 
 /** Shared email header: REGENERATIVE COMPUTE title + Powered by Regen Network */
 function emailHeader(): string {


### PR DESCRIPTION
## Summary
- Adds `regenLogoPNG` base64-encoded constant in `brand.ts` (361×162 transparent PNG, ~8.6KB)
- Adds `/logo.png` route in `server/index.ts` with long cache headers
- Updates `REGEN_LOGO_URL` in `email.ts` from `.svg` to `.png`
- Keeps `/logo.svg` endpoint for web pages

Closes #51

## Test plan
- [ ] Send a test email (magic link or welcome) and verify logo renders in Gmail
- [ ] Verify logo renders in Outlook web
- [ ] Verify `/logo.png` returns a valid PNG with `curl -I https://compute.regen.network/logo.png`
- [ ] Verify `/logo.svg` still works for web pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)