### PR TITLE
Fix duplicate records on retirement retry and transaction dedup

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -535,6 +535,16 @@ export function creditBalance(
   stripeSubscriptionId?: string
 ): void {
   const txn = db.transaction(() => {
+    // Prevent duplicate transactions from the same Stripe session
+    // (checkout.session.completed and invoice.paid can both fire for initial subscription payment)
+    const existing = db.prepare(
+      "SELECT id FROM transactions WHERE stripe_session_id = ? AND user_id = ?"
+    ).get(stripeSessionId, userId) as { id: number } | undefined;
+    if (existing) {
+      console.log(`Skipping duplicate transaction: session=${stripeSessionId} user=${userId} (already recorded as txn #${existing.id})`);
+      return;
+    }
+
     db.prepare(
       "UPDATE users SET balance_cents = balance_cents + ?, updated_at = datetime('now') WHERE id = ?"
     ).run(amountCents, userId);

--- a/src/services/retire-subscriber.ts
+++ b/src/services/retire-subscriber.ts
@@ -500,7 +500,10 @@ export async function retireForSubscriber(options: {
   };
 }
 
-/** Record retirement details in the subscriber_retirements table */
+/** Record retirement details in the subscriber_retirements table.
+ *  If a prior retirement exists with the same payment_id, UPDATE it and replace its batches
+ *  instead of creating a duplicate row. This handles retry-after-failure correctly.
+ */
 function recordSubscriberRetirement(
   db: Database.Database,
   data: {
@@ -518,23 +521,51 @@ function recordSubscriberRetirement(
   }
 ): void {
   const txn = db.transaction(() => {
-    // Insert main retirement record
-    const result = db.prepare(`
-      INSERT INTO subscriber_retirements (
-        subscriber_id, regen_address, gross_amount_cents, net_amount_cents,
-        credits_budget_cents, burn_budget_cents, ops_budget_cents,
-        total_credits_retired, total_spent_cents, payment_id
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      data.subscriberId, data.regenAddress, data.grossAmountCents,
-      data.netAmountCents, data.creditsBudgetCents, data.burnBudgetCents,
-      data.opsBudgetCents, data.totalCreditsRetired, data.totalSpentCents,
-      data.paymentId ?? null
-    );
+    let retirementId: number | bigint;
 
-    const retirementId = result.lastInsertRowid;
+    // Check if a prior retirement exists with the same payment_id (retry case)
+    const existing = data.paymentId
+      ? db.prepare(
+          "SELECT id FROM subscriber_retirements WHERE payment_id = ? AND subscriber_id = ?"
+        ).get(data.paymentId, data.subscriberId) as { id: number } | undefined
+      : undefined;
 
-    // Insert per-batch records
+    if (existing) {
+      // UPDATE the existing failed retirement record instead of inserting a duplicate
+      db.prepare(`
+        UPDATE subscriber_retirements SET
+          regen_address = ?, gross_amount_cents = ?, net_amount_cents = ?,
+          credits_budget_cents = ?, burn_budget_cents = ?, ops_budget_cents = ?,
+          total_credits_retired = ?, total_spent_cents = ?
+        WHERE id = ?
+      `).run(
+        data.regenAddress, data.grossAmountCents, data.netAmountCents,
+        data.creditsBudgetCents, data.burnBudgetCents, data.opsBudgetCents,
+        data.totalCreditsRetired, data.totalSpentCents,
+        existing.id
+      );
+      retirementId = existing.id;
+
+      // Delete old batch records (they'll be replaced with the merged results)
+      db.prepare("DELETE FROM subscriber_retirement_batches WHERE retirement_id = ?").run(retirementId);
+    } else {
+      // First attempt — insert new retirement record
+      const result = db.prepare(`
+        INSERT INTO subscriber_retirements (
+          subscriber_id, regen_address, gross_amount_cents, net_amount_cents,
+          credits_budget_cents, burn_budget_cents, ops_budget_cents,
+          total_credits_retired, total_spent_cents, payment_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        data.subscriberId, data.regenAddress, data.grossAmountCents,
+        data.netAmountCents, data.creditsBudgetCents, data.burnBudgetCents,
+        data.opsBudgetCents, data.totalCreditsRetired, data.totalSpentCents,
+        data.paymentId ?? null
+      );
+      retirementId = result.lastInsertRowid;
+    }
+
+    // Insert per-batch records (fresh for both new and retry)
     for (const batch of data.batches) {
       db.prepare(`
         INSERT INTO subscriber_retirement_batches (


### PR DESCRIPTION
## Summary

- **Retirement retry dedup**: `recordSubscriberRetirement()` now UPDATEs an existing failed record when retrying with the same `payment_id`, instead of INSERTing a duplicate row. Old failed batches are replaced with the merged retry results.
- **Transaction dedup**: `creditBalance()` now skips if a transaction with the same `stripe_session_id` + `user_id` already exists. Prevents the duplicate entry caused by both `checkout.session.completed` and `invoice.paid` firing for the initial subscription payment.

## Root Cause

Sub 12 (meyersconsult@yahoo.com) showed two entries on their dashboard because:
1. Initial subscription created transaction #14 via `checkout.session.completed`
2. `invoice.paid` webhook created transaction #16 with the same `stripe_session_id`
3. When we retried the failed retirement, `recordSubscriberRetirement()` created retirement #21 alongside the original failed #14

## Data Fix (already applied)

- Deleted duplicate transaction #16 (kept #14)
- Deleted failed retirement #14 and its 3 failed batches (kept retry #21 with successful batches)

## Test plan

- [ ] Verify Sub 12 dashboard shows single subscription entry
- [ ] Deploy to production and trigger a test retirement retry — confirm no duplicate rows
- [ ] Verify `checkout.session.completed` + `invoice.paid` for a new subscriber creates only 1 transaction

Closes #75, relates to #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)