### PR TITLE
Add webhook handlers for Stripe refunds and failed payments

### DIFF
--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -47,7 +47,7 @@ import { deriveSubscriberAddress } from "../services/subscriber-wallet.js";
 import { retireForSubscriber, accumulateBurnBudget, getPendingBurnBudget, markBurnExecuted, calculateNetAfterStripe, type SubscriberRetirementResult } from "../services/retire-subscriber.js";
 import { swapAndBurn, checkOsmosisReadiness } from "../services/swap-and-burn.js";
 import { getProjectForBatch } from "./project-metadata.js";
-import { checkAndSendMonthlyReminder, checkTradableStock } from "../services/admin-telegram.js";
+import { checkAndSendMonthlyReminder, checkTradableStock, sendTelegram } from "../services/admin-telegram.js";
 import { updateRegistryProfile } from "../services/registry-profile.js";
 import { brandFonts, brandCSS, brandHeader, brandFooter } from "./brand.js";
 
@@ -1032,6 +1032,29 @@ ${betaBannerJS()}
       // Note: handleInvoicePaid triggers retirement asynchronously (fire-and-forget)
       // so the webhook responds quickly. We still await the synchronous part (period updates).
       await handleInvoicePaid(db, invoice, baseUrl);
+    } else if (event.type === "invoice.payment_failed") {
+      const invoice = event.data.object as Stripe.Invoice;
+      const subDetails = invoice.parent?.subscription_details;
+      const subRef = subDetails?.subscription;
+      const subId = typeof subRef === "string" ? subRef : subRef?.id;
+      if (subId) {
+        const existing = getSubscriberByStripeId(db, subId);
+        if (existing) {
+          console.warn(`Payment failed for subscriber ${existing.id} (${subId}): ${invoice.id}`);
+          sendTelegram(
+            `\u26a0\ufe0f *Payment Failed*\nSubscriber ${existing.id} (${subId})\nInvoice: ${invoice.id}`
+          ).catch(() => {});
+        }
+      }
+    } else if (event.type === "charge.refunded") {
+      const charge = event.data.object as Stripe.Charge;
+      const amountRefunded = charge.amount_refunded ?? 0;
+      console.warn(`Charge refunded: ${charge.id}, amount=$${(amountRefunded / 100).toFixed(2)}`);
+      // Note: Credits already retired on-chain cannot be reversed.
+      // This is logged for accounting reconciliation.
+      sendTelegram(
+        `\ud83d\udcb8 *Charge Refunded*\nCharge: ${charge.id}\nAmount: $${(amountRefunded / 100).toFixed(2)}\n_Credits retired on-chain cannot be reversed._`
+      ).catch(() => {});
     }
 
     res.json({ received: true });

--- a/src/services/admin-telegram.ts
+++ b/src/services/admin-telegram.ts
@@ -19,7 +19,7 @@ import { listSellOrders } from "./ledger.js";
 const ADMIN_BOT_TOKEN = process.env.ADMIN_TELEGRAM_BOT_TOKEN;
 const ADMIN_CHAT_ID = process.env.ADMIN_TELEGRAM_CHAT_ID;
 
-async function sendTelegram(text: string, parseMode: string = "Markdown"): Promise<boolean> {
+export async function sendTelegram(text: string, parseMode: string = "Markdown"): Promise<boolean> {
   if (!ADMIN_BOT_TOKEN || !ADMIN_CHAT_ID) {
     console.warn("Admin Telegram not configured (ADMIN_TELEGRAM_BOT_TOKEN / ADMIN_TELEGRAM_CHAT_ID)");
     return false;


### PR DESCRIPTION
## Summary
- Add `invoice.payment_failed` webhook handler that logs a warning and sends a Telegram admin alert with subscriber and invoice details
- Add `charge.refunded` webhook handler that logs the refund amount and sends a Telegram alert noting that on-chain retirements cannot be reversed
- Export `sendTelegram` from `admin-telegram.ts` to support direct alerts from webhook handlers

Closes #78

## Test plan
- [ ] Trigger a `invoice.payment_failed` event via Stripe CLI (`stripe trigger invoice.payment_failed`) and verify console warning + Telegram alert
- [ ] Trigger a `charge.refunded` event via Stripe CLI and verify console warning + Telegram alert
- [ ] Verify build passes (`npm run build`)
- [ ] Verify existing webhook handlers (checkout.session.completed, invoice.paid, subscription events) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)