### PR TITLE
Fix Stripe webhook idempotency (#73)

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -8,6 +8,7 @@
  * - pool_runs: monthly batch retirement execution records
  * - attributions: per-subscriber fractional credit attribution per pool run
  * - burns: REGEN token burn records linked to pool runs
+ * - processed_webhook_events: Stripe webhook event deduplication
  */
 
 import Database from "better-sqlite3";
@@ -279,6 +280,12 @@ export function getDb(dbPath = "data/regen-compute.db"): Database.Database {
 
     CREATE INDEX IF NOT EXISTS idx_referral_rewards_referrer ON referral_rewards(referrer_user_id);
     CREATE INDEX IF NOT EXISTS idx_referral_rewards_status ON referral_rewards(status);
+
+    CREATE TABLE IF NOT EXISTS processed_webhook_events (
+      event_id TEXT PRIMARY KEY,
+      event_type TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
   `);
 
   // Migrations for existing DBs — add billing_interval to subscribers table
@@ -1368,4 +1375,14 @@ export function verifyMagicLinkToken(db: Database.Database, token: string): stri
   ).get(token) as { email: string } | undefined;
 
   return row?.email ?? null;
+}
+
+// --- Webhook idempotency ---
+
+export function isEventProcessed(db: Database.Database, eventId: string): boolean {
+  return !!db.prepare("SELECT 1 FROM processed_webhook_events WHERE event_id = ?").get(eventId);
+}
+
+export function markEventProcessed(db: Database.Database, eventId: string, eventType: string): void {
+  db.prepare("INSERT OR IGNORE INTO processed_webhook_events (event_id, event_type) VALUES (?, ?)").run(eventId, eventType);
 }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -38,6 +38,8 @@ import {
   setUserDisplayName,
   getSubscriberByUserId,
   getCumulativeAttribution,
+  isEventProcessed,
+  markEventProcessed,
 } from "./db.js";
 import { betaBannerCSS, betaBannerHTML, betaBannerJS } from "./beta-banner.js";
 import { sendWelcomeEmail, sendFirstRetirementEmail, sendRetirementReceiptEmail } from "../services/email.js";
@@ -941,6 +943,13 @@ ${betaBannerJS()}
       const body = Buffer.isBuffer(req.body) ? req.body.toString("utf8") : req.body;
       event = (typeof body === "string" ? JSON.parse(body) : body) as Stripe.Event;
     }
+
+    // Idempotency: skip duplicate webhook events (Stripe retries)
+    if (isEventProcessed(db, event.id)) {
+      console.log(`Skipping duplicate webhook event: ${event.id} (${event.type})`);
+      return res.json({ received: true });
+    }
+    markEventProcessed(db, event.id, event.type);
 
     if (event.type === "checkout.session.completed") {
       const session = event.data.object as Stripe.Checkout.Session;


### PR DESCRIPTION
## Summary
- Adds a `processed_webhook_events` table to track Stripe event IDs that have already been handled
- Checks for duplicate events at the top of the `/webhook` handler, returning `{ received: true }` early for retries
- Prevents double-creation of `burn_accumulator` entries and `scheduled_retirements` when Stripe retries `invoice.paid` (or any other webhook)

## Changes
- **`src/server/db.ts`**: New `processed_webhook_events` table in `getDb()`, plus `isEventProcessed()` and `markEventProcessed()` helper functions
- **`src/server/routes.ts`**: Idempotency guard inserted after event construction, before any event-type handling

## Test plan
- [ ] Deploy to staging and trigger a webhook via Stripe CLI (`stripe trigger invoice.paid`)
- [ ] Replay the same event and confirm the handler logs "Skipping duplicate webhook event" and returns 200
- [ ] Verify no duplicate rows in `burn_accumulator` or `scheduled_retirements`

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)