### PR TITLE
Fix: retry failed scheduled retirements

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -387,6 +387,14 @@ export function getDb(dbPath = "data/regen-compute.db"): Database.Database {
     console.log("Migration: updated scheduled_retirements CHECK constraint to include 'partial'");
   }
 
+  // Migration: add retry_count column to scheduled_retirements
+  try {
+    _db.prepare("ALTER TABLE scheduled_retirements ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0").run();
+    console.log("Migration: added retry_count column to scheduled_retirements");
+  } catch (e) {
+    // Column already exists
+  }
+
   // Backfill referral codes for users that don't have one
   const usersWithoutCodes = _db.prepare(
     "SELECT id FROM users WHERE referral_code IS NULL"
@@ -874,6 +882,7 @@ export interface ScheduledRetirement {
   status: "pending" | "running" | "completed" | "partial" | "failed";
   retirement_id: number | null;
   error: string | null;
+  retry_count: number;
   created_at: string;
   executed_at: string | null;
 }
@@ -894,7 +903,7 @@ export function createScheduledRetirement(
 
 export function getDueScheduledRetirements(db: Database.Database): ScheduledRetirement[] {
   return db.prepare(
-    "SELECT sr.* FROM scheduled_retirements sr JOIN subscribers s ON sr.subscriber_id = s.id WHERE sr.status IN ('pending', 'partial') AND sr.scheduled_date <= datetime('now') AND s.status = 'active' ORDER BY sr.scheduled_date ASC"
+    "SELECT sr.* FROM scheduled_retirements sr JOIN subscribers s ON sr.subscriber_id = s.id WHERE (sr.status IN ('pending', 'partial') OR (sr.status = 'failed' AND sr.retry_count < 3)) AND sr.scheduled_date <= datetime('now') AND s.status = 'active' ORDER BY sr.scheduled_date ASC"
   ).all() as ScheduledRetirement[];
 }
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -2061,12 +2061,13 @@ async function processScheduledRetirements(db: Database.Database, baseUrl?: stri
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      db.prepare("UPDATE scheduled_retirements SET retry_count = retry_count + 1 WHERE id = ?").run(scheduled.id);
       updateScheduledRetirement(db, scheduled.id, {
         status: "failed",
         error: msg,
         executed_at: new Date().toISOString(),
       });
-      console.error(`Scheduled retirement error: id=${scheduled.id} ${msg}`);
+      console.error(`Scheduled retirement error: id=${scheduled.id} retry_count=${(scheduled.retry_count ?? 0) + 1} ${msg}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `retry_count` column to `scheduled_retirements` table (with migration)
- Include failed retirements with `retry_count < 3` in `getDueScheduledRetirements()` query
- Increment `retry_count` on each failure in `processScheduledRetirements()`

Closes #74

## Test plan
- [ ] Verify migration adds `retry_count` column on existing DB
- [ ] Verify a failed scheduled retirement is picked up on next processing cycle
- [ ] Verify retirements stop retrying after 3 failures
- [ ] Verify cancelled subscriptions' failed retirements (error = 'subscription_cancelled') are not retried (subscriber status != 'active')

🤖 Generated with [Claude Code](https://claude.com/claude-code)