### PR TITLE
Fix yearly cancel not refunding front-loaded burn budget

### DIFF
--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1780,6 +1780,32 @@ function handleSubscriptionDeleted(db: Database.Database, sub: Stripe.Subscripti
       if (cancelled > 0) {
         console.log(`Cancelled ${cancelled} scheduled retirement(s) for subscriber ${existing.id}`);
       }
+
+      // Refund unused burn budget for yearly subscribers
+      if (existing.billing_interval === "yearly") {
+        // Count how many monthly retirements were actually executed
+        const executedCount = db.prepare(
+          "SELECT COUNT(*) as count FROM subscriber_retirements WHERE subscriber_id = ?"
+        ).get(existing.id) as { count: number };
+
+        const monthsUsed = executedCount.count;
+        const monthsUnused = Math.max(0, 12 - monthsUsed);
+
+        if (monthsUnused > 0) {
+          const yearlyNet = calculateNetAfterStripe(existing.amount_cents);
+          const yearlyBurnBudget = Math.floor(yearlyNet * 0.05);
+          const unusedBurn = Math.floor(yearlyBurnBudget * monthsUnused / 12);
+
+          if (unusedBurn > 0) {
+            // Insert negative entry to offset the front-loaded burn
+            accumulateBurnBudget(db, -unusedBurn);
+            console.log(
+              `Refunded unused burn budget for cancelled yearly subscriber ${existing.id}: ` +
+              `$${(unusedBurn / 100).toFixed(2)} (${monthsUnused} unused months of ${yearlyBurnBudget} total)`
+            );
+          }
+        }
+      }
     }
 
     console.log(`Subscription cancelled: ${stripeSubId}`);


### PR DESCRIPTION
## Summary

- When a yearly subscriber cancels, the front-loaded burn budget (5% of yearly net) was left in `burn_accumulator` even though the subscriber may have only used 1-2 of 12 months
- After `cancelScheduledRetirements()`, we now calculate the unused burn portion based on how many monthly retirements were actually executed vs. the 12-month plan
- Inserts a negative `burn_accumulator` entry via `accumulateBurnBudget(db, -unusedBurn)` to reverse the unused portion

## Test plan

- [ ] Create a yearly subscriber, execute 2 monthly retirements, then cancel — verify `burn_accumulator` gets a negative entry for 10/12 of the yearly burn budget
- [ ] Cancel a yearly subscriber with 0 executed retirements — verify full burn budget is refunded
- [ ] Cancel a monthly subscriber — verify no burn refund logic runs
- [ ] Cancel a yearly subscriber with all 12 retirements executed — verify no refund (monthsUnused = 0)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)