### PR TITLE
Fix scheduled retirements not adjusting on plan change

### DIFF
--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1762,6 +1762,39 @@ function handleSubscriptionUpdated(db: Database.Database, sub: Stripe.Subscripti
       current_period_start: periodStart,
       current_period_end: periodEnd,
     });
+
+    // If a yearly subscriber's amount changed, recalculate scheduled retirements
+    if (existing.billing_interval === "yearly" && amountCents !== existing.amount_cents) {
+      // Cancel existing pending scheduled retirements
+      const cancelled = db.prepare(
+        "UPDATE scheduled_retirements SET status = 'failed', error = 'plan_changed' WHERE subscriber_id = ? AND status = 'pending'"
+      ).run(existing.id);
+
+      if (cancelled.changes > 0) {
+        // Recalculate with new amount
+        const newNetTotal = calculateNetAfterStripe(amountCents);
+        const newMonthlyNet = Math.floor(newNetTotal / 12);
+        const newMonthlyGross = Math.floor(amountCents / 12);
+
+        // Recreate scheduled retirements for remaining months
+        const now = new Date();
+        for (let i = 0; i < cancelled.changes; i++) {
+          const scheduledDate = new Date(now);
+          scheduledDate.setMonth(scheduledDate.getMonth() + i + 1);
+          createScheduledRetirement(
+            db, existing.id, newMonthlyGross, newMonthlyNet,
+            scheduledDate.toISOString().split("T")[0],
+            "yearly"
+          );
+        }
+
+        console.log(
+          `Recalculated ${cancelled.changes} scheduled retirements for subscriber ${existing.id} ` +
+          `after plan change: $${(existing.amount_cents / 100).toFixed(2)} → $${(amountCents / 100).toFixed(2)}`
+        );
+      }
+    }
+
     console.log(`Subscription updated: ${stripeSubId} plan=${plan} interval=${billingInterval} status=${status}`);
   } catch (err) {
     console.error("Error handling subscription.updated:", err instanceof Error ? err.message : err);


### PR DESCRIPTION
## Summary

- When a yearly subscriber upgrades or downgrades via Stripe Billing Portal, `handleSubscriptionUpdated()` now detects that `amountCents` differs from `existing.amount_cents`
- Cancels all pending scheduled retirements (marked `status='failed'`, `error='plan_changed'`)
- Recreates the same number of scheduled retirements with recalculated monthly amounts based on the new plan price

## Test plan

- [ ] Simulate a yearly subscriber upgrade in Stripe test mode and verify old scheduled retirements are cancelled with `error='plan_changed'`
- [ ] Verify new scheduled retirements are created with correct `gross_amount_cents` and `net_amount_cents` reflecting the new plan
- [ ] Verify the count of new scheduled retirements matches the count of cancelled ones
- [ ] Verify monthly subscribers are unaffected (no scheduled retirements to recalculate)
- [ ] Verify downgrade path works the same way

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)