### PR TITLE
Add burn_accumulator audit trail (source_type, subscriber_id)

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -467,6 +467,17 @@ export function getDb(dbPath = "data/regen-compute.db"): Database.Database {
     WHERE type = 'subscription' AND billing_interval IS NULL
   `).run();
 
+  // Migration: add source_type and subscriber_id to burn_accumulator for audit trail (#77)
+  const burnCols = (_db.pragma("table_info(burn_accumulator)") as Array<{ name: string }>).map((c) => c.name);
+  if (!burnCols.includes("source_type")) {
+    _db.exec(`ALTER TABLE burn_accumulator ADD COLUMN source_type TEXT`);
+    console.log("Migration: added source_type column to burn_accumulator");
+  }
+  if (!burnCols.includes("subscriber_id")) {
+    _db.exec(`ALTER TABLE burn_accumulator ADD COLUMN subscriber_id INTEGER`);
+    console.log("Migration: added subscriber_id column to burn_accumulator");
+  }
+
   return _db;
 }
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1831,7 +1831,7 @@ function handleSubscriptionDeleted(db: Database.Database, sub: Stripe.Subscripti
 
           if (unusedBurn > 0) {
             // Insert negative entry to offset the front-loaded burn
-            accumulateBurnBudget(db, -unusedBurn);
+            accumulateBurnBudget(db, -unusedBurn, "yearly_cancel_refund", existing.id);
             console.log(
               `Refunded unused burn budget for cancelled yearly subscriber ${existing.id}: ` +
               `$${(unusedBurn / 100).toFixed(2)} (${monthsUnused} unused months of ${yearlyBurnBudget} total)`
@@ -1936,7 +1936,7 @@ async function handleInvoicePaid(db: Database.Database, invoice: Stripe.Invoice,
         // Monthly retirements will skip burn accumulation since it's already front-loaded.
         const yearlyBurnBudget = Math.floor(netTotal * 0.05); // 5% burn split
         if (yearlyBurnBudget > 0) {
-          accumulateBurnBudget(db, yearlyBurnBudget);
+          accumulateBurnBudget(db, yearlyBurnBudget, "yearly_frontload", existing.id);
           console.log(
             `Front-loaded yearly burn budget: $${(yearlyBurnBudget / 100).toFixed(2)} ` +
             `(5% of $${(netTotal / 100).toFixed(2)} net) for subscriber ${existing.id}`
@@ -2034,7 +2034,7 @@ function executeRetirementAsync(
     });
 
     if (!skipBurnAccumulation && result.burnBudgetCents > 0 && (result.status === "success" || result.status === "partial")) {
-      accumulateBurnBudget(db, result.burnBudgetCents);
+      accumulateBurnBudget(db, result.burnBudgetCents, "monthly_retirement", subscriberId);
       // Check if pending burn budget has reached threshold — trigger auto burn
       maybeExecuteAutoBurn(db).catch(() => {});
     }
@@ -2111,7 +2111,7 @@ async function processScheduledRetirements(db: Database.Database, baseUrl?: stri
 
         if (result.status === "success") {
           if (!isYearlyScheduled && result.burnBudgetCents > 0) {
-            accumulateBurnBudget(db, result.burnBudgetCents);
+            accumulateBurnBudget(db, result.burnBudgetCents, "scheduled_retirement", scheduled.subscriber_id);
             maybeExecuteAutoBurn(db).catch(() => {});
           }
           updateScheduledRetirement(db, scheduled.id, {
@@ -2129,7 +2129,7 @@ async function processScheduledRetirements(db: Database.Database, baseUrl?: stri
         } else if (result.status === "partial") {
           // Some batches succeeded, others failed — mark as partial so it will be retried
           if (!isYearlyScheduled && result.burnBudgetCents > 0) {
-            accumulateBurnBudget(db, result.burnBudgetCents);
+            accumulateBurnBudget(db, result.burnBudgetCents, "scheduled_retirement", scheduled.subscriber_id);
             maybeExecuteAutoBurn(db).catch(() => {});
           }
           updateScheduledRetirement(db, scheduled.id, {

--- a/src/services/retire-subscriber.ts
+++ b/src/services/retire-subscriber.ts
@@ -587,11 +587,16 @@ function recordSubscriberRetirement(
  * Accumulate burn budget from subscriber retirements.
  * Burns are executed separately (periodically) from the master wallet.
  */
-export function accumulateBurnBudget(db: Database.Database, amountCents: number): void {
+export function accumulateBurnBudget(
+  db: Database.Database,
+  amountCents: number,
+  sourceType?: string,
+  subscriberId?: number
+): void {
   db.prepare(`
-    INSERT INTO burn_accumulator (amount_cents)
-    VALUES (?)
-  `).run(amountCents);
+    INSERT INTO burn_accumulator (amount_cents, source_type, subscriber_id)
+    VALUES (?, ?, ?)
+  `).run(amountCents, sourceType ?? null, subscriberId ?? null);
 }
 
 /** Get total accumulated burn budget that hasn't been executed yet */


### PR DESCRIPTION
## Summary
- Added `source_type` (TEXT) and `subscriber_id` (INTEGER) columns to `burn_accumulator` table via migration in `getDb()`
- Updated `accumulateBurnBudget()` signature to accept optional `sourceType` and `subscriberId` parameters
- Updated all 4 call sites in `routes.ts` to pass source context: `yearly_frontload`, `monthly_retirement`, and `scheduled_retirement`

## Test plan
- [ ] Verify migration adds columns on existing DB without errors (idempotent check via `table_info`)
- [ ] Verify new burn_accumulator rows include source_type and subscriber_id
- [ ] Verify existing code paths (yearly frontload, monthly retirement, scheduled retirement) all pass correct labels
- [ ] Verify `npm run build` passes cleanly

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)