### PR TITLE
Update ecocredit imagery and descriptions to match app.regen.network

### DIFF
--- a/src/server/project-metadata.ts
+++ b/src/server/project-metadata.ts
@@ -45,10 +45,10 @@ export const PROJECTS: ProjectInfo[] = [
     creditTypeLabel: "Biodiversity",
     name: "El Globo Habitat Bank",
     description:
-      "A habitat bank in Antioquia, Colombia that protects and restores critical biodiversity corridors through Terrasos' pioneering framework for conservation banking.",
+      'El Globo is located in the "Cuchilla Jardin-Tamesis" Integrated Management District (DMI). Here ecosystem preservation, forest enhancement and restoration activities are implemented to generate positive and permanent impacts on biodiversity.',
     location: "Antioquia, Colombia",
     imageUrl:
-      "https://regen-registry.s3.amazonaws.com/projects/146f8ea0-c484-11ee-9ebb-0a6e1e09fcad/1707323979494-MONTA%C3%91AS.jpg",
+      "https://regen-registry.s3.amazonaws.com/projects/146f8ea0-c484-11ee-9ebb-0a6e1e09fcad/1707323455220-TANGRA%20DE%20LENTEJUELAS.jpg",
     projectPageUrl: "https://app.regen.network/project/BT01-001",
     accentColor: "#527984",
   },
@@ -57,9 +57,9 @@ export const PROJECTS: ProjectInfo[] = [
     creditClassId: "USS01",
     creditType: "USS",
     creditTypeLabel: "Species Stewardship",
-    name: "Biocultural Jaguar Credits",
+    name: "Biocultural Jaguar Credits, Ancestral Stewardship in the Sharamentsa Community",
     description:
-      "Indigenous stewards of the Sharamentsa community in Ecuador's Amazon protect 10,000 hectares of critical jaguar habitat through ancestral forest stewardship.",
+      "In the Amazon headwaters, Indigenous stewards face increasing pressure from activities like illegal logging and mining, which endanger both their forest ecosystem and cultural heritage. The Sharamentsa community, belonging to the Achuar Nation, is pivotal in this biodiversity project that focuses on safeguarding a critical 10,000-hectare jaguar habitat.",
     location: "Pastaza Province, Ecuador",
     imageUrl:
       "https://regen-registry.s3.amazonaws.com/projects/31f91f8c-8fd1-11ee-ba15-0267c2be097b/1732744057255-Jaguar_2023_RM_2.jpg",
@@ -73,7 +73,7 @@ export const PROJECTS: ProjectInfo[] = [
     creditTypeLabel: "Carbon",
     name: "Harvey Manning Park Expansion",
     description:
-      "Urban forest carbon credits from a park expansion in Issaquah, Washington, protecting native forest canopy in a rapidly developing area near Seattle.",
+      'The 15.14 acre Harvey Manning Park Expansion project is part of 33 acres in the "Issaquah Alps" comprised of Tiger, Squak, and Cougar Mountains, above Lake Sammamish. The 100+ year old forest includes riparian and wetland habitat that supports wildlife corridors on Cougar Mountain and protects cool freshwater streams that feed Tibbetts Creek, a salmon-bearing tributary to Lake Sammamish.',
     location: "Issaquah, Washington",
     imageUrl:
       "https://regen-registry.s3.amazonaws.com/projects/C02/harvey-manning-01.jpg",
@@ -85,12 +85,12 @@ export const PROJECTS: ProjectInfo[] = [
     creditClassId: "C02",
     creditType: "C",
     creditTypeLabel: "Carbon",
-    name: "St. Elmo Preservation",
+    name: "St. Elmo Preservation Project",
     description:
-      "Urban forest carbon credits from a preservation effort in Chattanooga, Tennessee, protecting mature tree canopy that provides critical ecosystem services to the local community.",
+      "Lookout Mountain is one of the most biologically diverse and critically imperiled ecoregions in the world stretching 90+ miles across three states; Tennessee, Alabama, and Georgia. The 58 acre oak-pine forest is situated between the Chickamauga & Chattanooga National Military Park and the historic St. Elmo neighborhood. By protecting this property, the Conservancy ensures connectivity between habitat corridors and provides essential wildlife habitat for several species.",
     location: "Chattanooga, Tennessee",
     imageUrl:
-      "https://regen-registry.s3.amazonaws.com/projects/1f484f70-16cd-11ee-ab29-0a6e1e09fcad/1688575971540-Photo%20Oct%2023,%2011%2015%2024%20AM.jpg",
+      "https://regen-registry.s3.amazonaws.com/projects/1f484f70-16cd-11ee-ab29-0a6e1e09fcad/1688078599319-Photo%20Oct%2023,%2011%2028%2022%20AM.jpg",
     projectPageUrl: "https://app.regen.network/project/C02-006",
     accentColor: "#4FB573",
   },
@@ -101,7 +101,7 @@ export const PROJECTS: ProjectInfo[] = [
     creditTypeLabel: "Carbon",
     name: "Pimlico Farm",
     description:
-      "Regenerative agriculture on managed cropland and grassland in the UK, building soil carbon through improved land management practices.",
+      "The primary indicator in this credit class is soil organic carbon stocks (SOCS). Levels will be increased by growing harvestable and cover crops and grass to maximise canopy and root growth while incorporating crop residues and manures. Reduced soil disturbance, maintaining soil cover and returning crop residues will maximise retained organic matter in the soil.",
     location: "Oxfordshire, United Kingdom",
     imageUrl:
       "https://regen-registry.s3.amazonaws.com/projects/8cb44ebc-e532-11ef-8178-0afffa81c869/1738925262683-4.jpeg",
@@ -113,9 +113,9 @@ export const PROJECTS: ProjectInfo[] = [
     creditClassId: "KSH01",
     creditType: "KSH",
     creditTypeLabel: "Regenerative Grazing",
-    name: "Grgich Hills Sheep Grazing",
+    name: "Grgich Hills Estate Regenerative Sheep Grazing",
     description:
-      "Kilo-Sheep-Hour credits from regenerative vineyard grazing in Napa Valley. Sheep replace herbicides and machinery, building soil health while producing world-class wine.",
+      "This project uses high-density, short-duration rotational sheep grazing in vineyard systems to improve ecosystem functioning through active management of the soil and herbaceous cover in the vineyard understory. The practice improves soil health, reduces use of herbicides or mowing, and enhances carbon storage.",
     location: "Napa Valley, California",
     imageUrl:
       "https://regen-registry.s3.amazonaws.com/projects/d1a8c4ec-4cf6-11ee-9623-0a6e1e09fcad/1694034028766-grgich1.jpg",


### PR DESCRIPTION
## Summary
- Updated all 6 project names, descriptions, and hero images in `src/server/project-metadata.ts` to match the official listings on [app.regen.network](https://app.regen.network)
- Sourced metadata from each project's OpenGraph tags (og:title, og:description, og:image) to ensure consistency with the marketplace
- Build passes cleanly with no code logic changes

## Changes per project
| Project | What changed |
|---------|-------------|
| BT01-001 (El Globo) | Description + hero image URL |
| USS01-002 (Jaguar) | Full registry name + description |
| C02-004 (Harvey Manning) | Description |
| C02-006 (St. Elmo) | Full registry name + description + hero image URL |
| C06-002 (Pimlico Farm) | Description |
| KSH01-001 (Grgich Hills) | Full registry name + description |

Closes #71

## Test plan
- [ ] Verify `npm run build` passes
- [ ] Check dashboard at compute.regen.network — project cards should display updated names, descriptions, and images
- [ ] Spot-check each image URL loads correctly in a browser
- [ ] Compare card content with corresponding pages on app.regen.network

🤖 Generated with [Claude Code](https://claude.com/claude-code)