### PR TITLE
add: burn/pool MCP tools, prompts, CLI burn-run, REST endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import { getRetirementCertificate } from "./tools/certificates.js";
 import { getImpactSummary } from "./tools/impact.js";
 import { retireCredits } from "./tools/retire.js";
 import { checkSubscriptionStatus } from "./tools/subscription.js";
+import { getBurnStatus } from "./tools/burn-status.js";
+import { getPoolHistory } from "./tools/pool-history.js";
 import { loadConfig, isWalletConfigured } from "./config.js";
 import {
   fetchRegistry,
@@ -62,6 +64,13 @@ POOL RETIREMENT:
   Use --dry-run to calculate without broadcasting transactions.
   Requires REGEN_WALLET_MNEMONIC for live runs.
 
+BURN RUN:
+  npx regen-compute burn-run [--dry-run]
+  Executes REGEN buy-back-and-burn from the pending burn accumulator.
+  Swaps USDC/OSMO → REGEN on Osmosis, IBC transfers to Regen, then burns.
+  Use --dry-run to simulate without broadcasting transactions.
+  Requires REGEN_WALLET_MNEMONIC and funded Osmosis wallet.
+
 CONFIGURATION:
   Copy .env.example to .env to customize. The server works without any
   configuration — read-only tools (footprint, browsing, impact) need no keys.
@@ -113,6 +122,49 @@ if (args[0] === "serve") {
       console.error(`Pool run failed: ${msg}`);
       process.exit(1);
     }
+  });
+} else if (args[0] === "burn-run") {
+  // Handle "burn-run" subcommand — execute REGEN buy-back-and-burn
+  const dryRun = args.includes("--dry-run");
+  import("./services/swap-and-burn.js").then(async ({ swapAndBurn, checkOsmosisReadiness, formatSwapAndBurnResult }) => {
+    import("./services/retire-subscriber.js").then(async ({ getPendingBurnBudget }) => {
+      import("./server/db.js").then(async ({ getDb }) => {
+        try {
+          const db = getDb(process.env.REGEN_DB_PATH ?? "data/regen-compute.db");
+          const pendingCents = getPendingBurnBudget(db);
+
+          if (pendingCents <= 0) {
+            console.log("No pending burn budget. Nothing to do.");
+            process.exit(0);
+          }
+
+          console.log(dryRun
+            ? `Burn run (DRY RUN): $${(pendingCents / 100).toFixed(2)} pending`
+            : `Burn run: $${(pendingCents / 100).toFixed(2)} pending`);
+
+          console.log("\nChecking Osmosis readiness...");
+          const readiness = await checkOsmosisReadiness();
+          console.log(`  Osmosis address: ${readiness.osmoAddress}`);
+          console.log(`  OSMO: ${readiness.osmoBalance.toFixed(6)}, USDC: ${readiness.usdcBalance.toFixed(6)}`);
+
+          if (!readiness.ready && !dryRun) {
+            console.error("\nOsmosis wallet not ready:");
+            for (const issue of readiness.issues) console.error(`  - ${issue}`);
+            process.exit(1);
+          }
+
+          const result = await swapAndBurn({ allocationCents: pendingCents, dryRun });
+          console.log("\n" + formatSwapAndBurnResult(result));
+          console.log("\nJSON output:");
+          console.log(JSON.stringify(result, null, 2));
+          process.exit(result.status === "failed" ? 1 : 0);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(`Burn run failed: ${msg}`);
+          process.exit(1);
+        }
+      });
+    });
   });
 } else {
 
@@ -372,6 +424,44 @@ server.tool(
   },
   async () => {
     return checkSubscriptionStatus();
+  }
+);
+
+// Tool: REGEN burn status and accumulator
+server.tool(
+  "get_burn_status",
+  "Shows the current REGEN burn accumulator balance, total REGEN burned to date, and recent burn transactions. Use this when the user asks about the REGEN burn flywheel, wants to see how much REGEN has been burned from subscriptions, or is curious about the deflationary mechanism. The 5% burn allocation from each subscription payment buys and burns REGEN tokens on-chain.",
+  {},
+  {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  async () => {
+    return getBurnStatus();
+  }
+);
+
+// Tool: Pool run history and attributions
+server.tool(
+  "get_pool_history",
+  "Shows the history of monthly pool retirement runs and per-subscriber credit attributions. Use this when the user asks about past retirement batches, wants to see how subscription revenue was deployed, or needs to understand the pool retirement mechanism. Each pool run aggregates subscriber revenue and retires credits across multiple batches.",
+  {
+    limit: z
+      .number()
+      .optional()
+      .default(5)
+      .describe("Number of recent pool runs to show (default: 5)"),
+  },
+  {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  async ({ limit }) => {
+    return getPoolHistory(limit);
   }
 );
 
@@ -762,6 +852,94 @@ if (ecoBridgeEnabled) {
     }
   );
 }
+
+// Prompt: Check burn impact
+server.prompt(
+  "check_my_burn_impact",
+  "See how the REGEN burn flywheel works — pending burn budget, total REGEN burned, and recent burn transactions.",
+  async () => {
+    return {
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: [
+              `I'd like to understand the REGEN burn mechanism and see its impact.`,
+              ``,
+              `Please:`,
+              `1. Use get_burn_status to show the current burn accumulator and history`,
+              `2. Explain how the 5% burn allocation works (subscription revenue → buy REGEN → burn on-chain)`,
+              `3. Summarize the total REGEN burned and what that means for the network`,
+              `4. If there's a pending burn budget, mention when the next burn is expected`,
+              ``,
+              `Frame this as the deflationary flywheel that makes every subscription more impactful over time.`,
+            ].join("\n"),
+          },
+        },
+      ],
+    };
+  }
+);
+
+// Prompt: Explore pool history
+server.prompt(
+  "explore_pool_history",
+  "Review the history of monthly pool retirement runs — how subscription revenue was deployed into ecological credits.",
+  async () => {
+    return {
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: [
+              `Show me the history of Regenerative Compute pool retirements.`,
+              ``,
+              `Please:`,
+              `1. Use get_pool_history to pull recent pool runs`,
+              `2. Summarize how much revenue was collected and how many credits were retired`,
+              `3. Show the batch breakdown for the most recent run`,
+              `4. If subscriber attributions are available, explain how individual contributions are tracked`,
+              `5. Use get_impact_summary for broader network context`,
+              ``,
+              `Frame this as transparent accounting — every dollar traceable from subscription to on-chain retirement.`,
+            ].join("\n"),
+          },
+        },
+      ],
+    };
+  }
+);
+
+// Prompt: Check supply and retire
+server.prompt(
+  "check_supply_and_retire",
+  "Check what credits are available on the marketplace, assess supply health, and retire credits to fund regeneration.",
+  async () => {
+    return {
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: [
+              `I'd like to check what ecological credits are available and potentially retire some.`,
+              ``,
+              `Please:`,
+              `1. Use browse_available_credits to show the current marketplace inventory`,
+              `2. Summarize the available credit types and pricing`,
+              `3. Use retire_credits to help me retire credits (on-chain or via marketplace link)`,
+              `4. After retirement, use get_retirement_certificate to retrieve the proof`,
+              ``,
+              `Help me choose based on impact and availability. Frame as funding ecological regeneration.`,
+            ].join("\n"),
+          },
+        },
+      ],
+    };
+  }
+);
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/src/server/api-routes.ts
+++ b/src/server/api-routes.ts
@@ -43,6 +43,7 @@ import { verifyPayment, getEvmChainCoingeckoId } from "../services/crypto-verify
 import { toUsdCents } from "../services/crypto-price.js";
 import { deriveSubscriberAddress } from "../services/subscriber-wallet.js";
 import { calculateNetAfterStripe, retireForSubscriber } from "../services/retire-subscriber.js";
+import { getBurnLedger } from "../services/accounting.js";
 
 // Credit type abbreviation to human-readable name
 const CREDIT_TYPE_NAMES: Record<string, string> = {
@@ -728,6 +729,110 @@ export function createApiRoutes(
       subscribe_url: subscribeUrl,
       manage_url: `${baseUrl}/manage?email=${encodeURIComponent(user.email ?? "")}`,
     });
+  });
+
+  // --- GET /api/v1/pool/history ---
+  router.get("/api/v1/pool/history", (req: Request, res: Response) => {
+    const user = getUser(req);
+    if (!user) return;
+
+    const limit = Math.min(parseInt((req.query.limit as string) || "10", 10), 50);
+
+    try {
+      const runs = db.prepare(
+        "SELECT * FROM pool_runs ORDER BY id DESC LIMIT ?"
+      ).all(limit) as Array<{
+        id: number; run_date: string; status: string;
+        total_revenue_cents: number; total_spent_cents: number;
+        carbon_credits_retired: number; carbon_tx_hash: string | null;
+        biodiversity_credits_retired: number; biodiversity_tx_hash: string | null;
+        uss_credits_retired: number; uss_tx_hash: string | null;
+        burn_allocation_cents: number; burn_tx_hash: string | null;
+        ops_allocation_cents: number; carry_forward_cents: number;
+        subscriber_count: number; dry_run: number;
+        error_log: string | null; created_at: string; completed_at: string | null;
+      }>;
+
+      // Get attributions for the most recent run
+      let latestAttributions: Array<{
+        subscriber_id: number; contribution_cents: number;
+        carbon_credits: number; biodiversity_credits: number; uss_credits: number;
+      }> = [];
+      if (runs.length > 0) {
+        latestAttributions = db.prepare(
+          "SELECT subscriber_id, contribution_cents, carbon_credits, biodiversity_credits, uss_credits FROM attributions WHERE pool_run_id = ?"
+        ).all(runs[0].id) as typeof latestAttributions;
+      }
+
+      res.json({
+        total_runs: runs.length,
+        runs: runs.map((r) => ({
+          id: r.id,
+          run_date: r.run_date,
+          status: r.status,
+          dry_run: !!r.dry_run,
+          subscriber_count: r.subscriber_count,
+          total_revenue_cents: r.total_revenue_cents,
+          total_spent_cents: r.total_spent_cents,
+          carbon_credits_retired: r.carbon_credits_retired,
+          biodiversity_credits_retired: r.biodiversity_credits_retired,
+          uss_credits_retired: r.uss_credits_retired,
+          burn_allocation_cents: r.burn_allocation_cents,
+          ops_allocation_cents: r.ops_allocation_cents,
+          carry_forward_cents: r.carry_forward_cents,
+          error_log: r.error_log,
+          created_at: r.created_at,
+          completed_at: r.completed_at,
+        })),
+        latest_attributions: latestAttributions,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      apiError(res, 500, "INTERNAL_ERROR", `Failed to fetch pool history: ${msg}`);
+    }
+  });
+
+  // --- GET /api/v1/burn/history ---
+  router.get("/api/v1/burn/history", (req: Request, res: Response) => {
+    const user = getUser(req);
+    if (!user) return;
+
+    try {
+      const entries = getBurnLedger(db);
+
+      // Pending burn budget
+      const pendingRow = db.prepare(`
+        SELECT COALESCE(SUM(amount_cents), 0) AS total
+        FROM burn_accumulator WHERE executed = 0
+      `).get() as { total: number } | undefined;
+      const pendingCents = pendingRow?.total ?? 0;
+
+      // Totals
+      const totalRegen = entries
+        .filter((e) => e.status === "completed")
+        .reduce((sum, e) => sum + e.regenBurned, 0);
+      const totalAllocationCents = entries.reduce((sum, e) => sum + e.allocationCents, 0);
+
+      res.json({
+        pending_burn_budget_cents: pendingCents,
+        total_regen_burned: totalRegen,
+        total_allocation_cents: totalAllocationCents,
+        total_burn_transactions: entries.filter((e) => e.status === "completed").length,
+        burns: entries.map((e) => ({
+          id: e.id,
+          date: e.date,
+          allocation_cents: e.allocationCents,
+          regen_burned: e.regenBurned,
+          regen_price_usd: e.regenPriceUsd,
+          tx_hash: e.txHash,
+          status: e.status,
+          source: e.source,
+        })),
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      apiError(res, 500, "INTERNAL_ERROR", `Failed to fetch burn history: ${msg}`);
+    }
   });
 
   return router;

--- a/src/server/openapi.json
+++ b/src/server/openapi.json
@@ -181,6 +181,62 @@
         }
       }
     },
+    "/pool/history": {
+      "get": {
+        "operationId": "getPoolHistory",
+        "summary": "Get pool retirement history",
+        "description": "Returns the history of monthly pool retirement runs with revenue, credit retirements, burn allocations, and per-subscriber attributions for the most recent run.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of pool runs to return (max 50)",
+            "schema": {
+              "type": "integer",
+              "default": 10,
+              "maximum": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pool run history with attributions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PoolHistoryResponse"
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/burn/history": {
+      "get": {
+        "operationId": "getBurnHistory",
+        "summary": "Get REGEN burn history",
+        "description": "Returns the full burn ledger including pending burn budget, total REGEN burned, and individual burn transaction records.",
+        "responses": {
+          "200": {
+            "description": "Burn history with accumulator status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BurnHistoryResponse"
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
     "/impact": {
       "get": {
         "operationId": "getImpact",
@@ -368,6 +424,71 @@
               "properties": {
                 "abbreviation": { "type": "string" },
                 "name": { "type": "string" }
+              }
+            }
+          }
+        }
+      },
+      "PoolHistoryResponse": {
+        "type": "object",
+        "properties": {
+          "total_runs": { "type": "integer" },
+          "runs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "integer" },
+                "run_date": { "type": "string" },
+                "status": { "type": "string" },
+                "dry_run": { "type": "boolean" },
+                "subscriber_count": { "type": "integer" },
+                "total_revenue_cents": { "type": "integer" },
+                "total_spent_cents": { "type": "integer" },
+                "carbon_credits_retired": { "type": "number" },
+                "biodiversity_credits_retired": { "type": "number" },
+                "uss_credits_retired": { "type": "number" },
+                "burn_allocation_cents": { "type": "integer" },
+                "ops_allocation_cents": { "type": "integer" },
+                "carry_forward_cents": { "type": "integer" }
+              }
+            }
+          },
+          "latest_attributions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "subscriber_id": { "type": "integer" },
+                "contribution_cents": { "type": "integer" },
+                "carbon_credits": { "type": "number" },
+                "biodiversity_credits": { "type": "number" },
+                "uss_credits": { "type": "number" }
+              }
+            }
+          }
+        }
+      },
+      "BurnHistoryResponse": {
+        "type": "object",
+        "properties": {
+          "pending_burn_budget_cents": { "type": "integer" },
+          "total_regen_burned": { "type": "number" },
+          "total_allocation_cents": { "type": "integer" },
+          "total_burn_transactions": { "type": "integer" },
+          "burns": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "integer" },
+                "date": { "type": "string" },
+                "allocation_cents": { "type": "integer" },
+                "regen_burned": { "type": "number" },
+                "regen_price_usd": { "type": "number", "nullable": true },
+                "tx_hash": { "type": "string", "nullable": true },
+                "status": { "type": "string" },
+                "source": { "type": "string" }
               }
             }
           }

--- a/src/tools/burn-status.ts
+++ b/src/tools/burn-status.ts
@@ -1,0 +1,97 @@
+/**
+ * MCP tool: get_burn_status
+ *
+ * Exposes REGEN burn accumulator state, total burned to date, and
+ * last burn transaction from the burns table and burn_accumulator.
+ */
+
+import { getDb } from "../server/db.js";
+import { getTotalBurnedRegen, type Burn } from "../server/db.js";
+
+export async function getBurnStatus(): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+}> {
+  try {
+    const db = getDb(process.env.REGEN_DB_PATH ?? "data/regen-compute.db");
+
+    // Pending burn budget (unexecuted accumulator entries)
+    const pendingRow = db.prepare(`
+      SELECT COALESCE(SUM(amount_cents), 0) AS total
+      FROM burn_accumulator WHERE executed = 0
+    `).get() as { total: number } | undefined;
+    const pendingCents = pendingRow?.total ?? 0;
+
+    // Total burned to date
+    const { total_regen, total_burns } = getTotalBurnedRegen(db);
+
+    // Last completed burn
+    const lastBurn = db.prepare(`
+      SELECT * FROM burns WHERE status = 'completed' ORDER BY created_at DESC LIMIT 1
+    `).get() as Burn | undefined;
+
+    // All-time burn allocation total
+    const allocationRow = db.prepare(`
+      SELECT COALESCE(SUM(allocation_cents), 0) AS total FROM burns
+    `).get() as { total: number } | undefined;
+    const totalAllocationCents = allocationRow?.total ?? 0;
+
+    // Recent burns (last 5)
+    const recentBurns = db.prepare(`
+      SELECT * FROM burns ORDER BY created_at DESC LIMIT 5
+    `).all() as Burn[];
+
+    const lines: string[] = [
+      `## REGEN Burn Status`,
+      ``,
+      `The 5% burn allocation from each subscription payment buys and burns REGEN tokens,`,
+      `creating a deflationary flywheel: retirements → burns → token scarcity → more retirements.`,
+      ``,
+      `### Summary`,
+      ``,
+      `| Metric | Value |`,
+      `|--------|-------|`,
+      `| Pending burn budget | $${(pendingCents / 100).toFixed(2)} |`,
+      `| Total REGEN burned | ${total_regen.toFixed(6)} REGEN |`,
+      `| Completed burn transactions | ${total_burns} |`,
+      `| Total burn allocation (all time) | $${(totalAllocationCents / 100).toFixed(2)} |`,
+    ];
+
+    if (lastBurn) {
+      lines.push(
+        ``,
+        `### Last Burn`,
+        ``,
+        `| Field | Value |`,
+        `|-------|-------|`,
+        `| Date | ${lastBurn.created_at} |`,
+        `| REGEN burned | ${lastBurn.amount_regen.toFixed(6)} |`,
+        `| Allocation | $${(lastBurn.allocation_cents / 100).toFixed(2)} |`,
+        `| REGEN price | ${lastBurn.regen_price_usd !== null ? `$${lastBurn.regen_price_usd.toFixed(6)}` : "—"} |`,
+        `| Tx hash | ${lastBurn.tx_hash ? `\`${lastBurn.tx_hash}\`` : "—"} |`,
+      );
+    }
+
+    if (recentBurns.length > 0) {
+      lines.push(
+        ``,
+        `### Recent Burns`,
+        ``,
+        `| Date | Status | REGEN | Allocation | Tx |`,
+        `|------|--------|-------|------------|-----|`,
+      );
+      for (const b of recentBurns) {
+        const tx = b.tx_hash ? `\`${b.tx_hash.slice(0, 12)}...\`` : "—";
+        lines.push(
+          `| ${b.created_at.split("T")[0]} | ${b.status} | ${b.amount_regen.toFixed(4)} | $${(b.allocation_cents / 100).toFixed(2)} | ${tx} |`
+        );
+      }
+    }
+
+    return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text" as const, text: `Error fetching burn status: ${message}` }],
+    };
+  }
+}

--- a/src/tools/pool-history.ts
+++ b/src/tools/pool-history.ts
@@ -1,0 +1,110 @@
+/**
+ * MCP tool: get_pool_history
+ *
+ * Exposes pool_run history and per-subscriber attributions from
+ * the pool_runs and attributions tables.
+ */
+
+import { getDb } from "../server/db.js";
+import {
+  getAttributionsByRun,
+  getPoolRunBatches,
+  type PoolRun,
+  type Attribution,
+  type PoolRunBatch,
+} from "../server/db.js";
+
+export async function getPoolHistory(
+  limit: number = 5
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+}> {
+  try {
+    const db = getDb(process.env.REGEN_DB_PATH ?? "data/regen-compute.db");
+
+    const runs = db.prepare(
+      "SELECT * FROM pool_runs ORDER BY id DESC LIMIT ?"
+    ).all(limit) as PoolRun[];
+
+    if (runs.length === 0) {
+      return {
+        content: [{
+          type: "text" as const,
+          text: "## Pool Run History\n\nNo pool runs have been executed yet.",
+        }],
+      };
+    }
+
+    const lines: string[] = [
+      `## Pool Run History`,
+      ``,
+      `Monthly pool retirements aggregate subscription revenue and retire credits on behalf of all subscribers.`,
+      ``,
+      `### Recent Runs`,
+      ``,
+      `| # | Date | Status | Subscribers | Revenue | Spent | Credits | Burn |`,
+      `|---|------|--------|-------------|---------|-------|---------|------|`,
+    ];
+
+    for (const run of runs) {
+      const totalCredits =
+        run.carbon_credits_retired +
+        run.biodiversity_credits_retired +
+        run.uss_credits_retired;
+      const dryTag = run.dry_run ? " (dry)" : "";
+      lines.push(
+        `| ${run.id} | ${run.run_date} | ${run.status}${dryTag} | ${run.subscriber_count} | $${(run.total_revenue_cents / 100).toFixed(2)} | $${(run.total_spent_cents / 100).toFixed(2)} | ${totalCredits.toFixed(4)} | $${(run.burn_allocation_cents / 100).toFixed(2)} |`
+      );
+    }
+
+    // Show detail for the most recent run
+    const latest = runs[0];
+    const batches = getPoolRunBatches(db, latest.id);
+    const attributions = getAttributionsByRun(db, latest.id);
+
+    if (batches.length > 0) {
+      lines.push(
+        ``,
+        `### Run #${latest.id} — Batch Breakdown`,
+        ``,
+        `| Batch | Type | Budget | Spent | Credits | Tx |`,
+        `|-------|------|--------|-------|---------|-----|`,
+      );
+      for (const b of batches) {
+        const tx = b.tx_hash ? `\`${b.tx_hash.slice(0, 12)}...\`` : (b.error ? `err: ${b.error.slice(0, 30)}` : "—");
+        lines.push(
+          `| ${b.batch_denom} | ${b.credit_type_abbrev} | $${(b.budget_cents / 100).toFixed(2)} | $${(b.spent_cents / 100).toFixed(2)} | ${b.credits_retired.toFixed(4)} | ${tx} |`
+        );
+      }
+    }
+
+    if (attributions.length > 0) {
+      lines.push(
+        ``,
+        `### Run #${latest.id} — Subscriber Attributions (${attributions.length} subscribers)`,
+        ``,
+        `| Subscriber | Contribution | Carbon | Biodiversity | USS |`,
+        `|------------|-------------|--------|-------------|-----|`,
+      );
+      for (const a of attributions.slice(0, 20)) {
+        lines.push(
+          `| #${a.subscriber_id} | $${(a.contribution_cents / 100).toFixed(2)} | ${a.carbon_credits.toFixed(4)} | ${a.biodiversity_credits.toFixed(4)} | ${a.uss_credits.toFixed(4)} |`
+        );
+      }
+      if (attributions.length > 20) {
+        lines.push(`| ... | *${attributions.length - 20} more* | | | |`);
+      }
+    }
+
+    if (latest.error_log) {
+      lines.push(``, `> **Errors:** ${latest.error_log}`);
+    }
+
+    return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text" as const, text: `Error fetching pool history: ${message}` }],
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Surfaces existing burn, pool, and accounting service-layer functions through MCP tools, MCP prompts, a CLI subcommand, and REST API endpoints. Every addition calls functions that already exist — no new business logic.

**9 additions total:**
- 2 MCP tools (`get_burn_status`, `get_pool_history`)
- 3 MCP prompts (`check_my_burn_impact`, `explore_pool_history`, `check_supply_and_retire`)
- 1 CLI subcommand (`burn-run`)
- 2 REST endpoints (`/api/v1/pool/history`, `/api/v1/burn/history`)
- OpenAPI spec updated with 2 new paths + 2 response schemas

## Changes in detail

### MCP tool: `get_burn_status`

**New file**: `src/tools/burn-status.ts`

Queries `burn_accumulator` (pending budget), `burns` table (completed burns, totals), and `getTotalBurnedRegen()` from `db.ts`. Returns:
- Pending burn budget in USD
- Total REGEN burned to date
- Completed burn transaction count
- Last burn details (date, amount, price, tx hash)
- Table of 5 most recent burns

### MCP tool: `get_pool_history`

**New file**: `src/tools/pool-history.ts`

Queries `pool_runs` table directly, plus `getPoolRunBatches()` and `getAttributionsByRun()` from `db.ts`. Accepts a `limit` parameter (default 5). Returns:
- Summary table of recent pool runs (date, status, subscribers, revenue, spent, credits, burn)
- Batch breakdown for the most recent run (batch denom, type, budget, spent, credits, tx)
- Subscriber attributions for the most recent run (contribution, carbon, biodiversity, USS)

### MCP prompts (3 new)

All added to `src/index.ts` following the exact pattern of existing prompts:

| Prompt | Workflow |
|--------|----------|
| `check_my_burn_impact` | `get_burn_status` → explain the 5% burn flywheel → summarize impact |
| `explore_pool_history` | `get_pool_history` → summarize revenue deployed → batch breakdown → `get_impact_summary` for context |
| `check_supply_and_retire` | `browse_available_credits` → summarize options → `retire_credits` → `get_retirement_certificate` |

### CLI: `regen-compute burn-run [--dry-run]`

**Modified**: `src/index.ts`

Follows the exact `pool-run` handler pattern:
1. Gets pending burn budget from `burn_accumulator` via `getPendingBurnBudget()`
2. Runs `checkOsmosisReadiness()` to verify wallet state
3. If not ready and not `--dry-run`, exits with error and issue list
4. Calls `swapAndBurn()` with the pending allocation
5. Outputs `formatSwapAndBurnResult()` + JSON

### REST: `GET /api/v1/pool/history`

**Modified**: `src/server/api-routes.ts`

Behind existing auth + rate-limit middleware. Queries `pool_runs` and `attributions` tables directly. Returns:
- `runs[]`: Pool run records (id, date, status, subscriber_count, revenue, spent, credits by type, burn, ops, carry_forward)
- `latest_attributions[]`: Per-subscriber attribution for the most recent run
- `?limit=N` query param (max 50)

### REST: `GET /api/v1/burn/history`

**Modified**: `src/server/api-routes.ts`

Behind existing auth + rate-limit middleware. Calls `getBurnLedger()` from `services/accounting.ts` and queries `burn_accumulator`. Returns:
- `pending_burn_budget_cents`: Unexecuted accumulator total
- `total_regen_burned`: Sum of all completed burns
- `total_allocation_cents`: All-time burn allocation
- `burns[]`: Full burn ledger (id, date, allocation, regen_burned, price, tx_hash, status, source)

### OpenAPI spec

**Modified**: `src/server/openapi.json`

Added paths: `/pool/history`, `/burn/history`
Added schemas: `PoolHistoryResponse`, `BurnHistoryResponse`

## Files changed

| File | Change |
|------|--------|
| `src/tools/burn-status.ts` | **New** — get_burn_status MCP tool |
| `src/tools/pool-history.ts` | **New** — get_pool_history MCP tool |
| `src/index.ts` | 2 tool imports, 2 tool registrations, 3 prompts, 1 CLI subcommand, help text |
| `src/server/api-routes.ts` | 1 import, 2 REST endpoints |
| `src/server/openapi.json` | 2 path entries, 2 response schemas |

## Service functions called (all pre-existing)

| Function | Source | Called by |
|----------|--------|----------|
| `getTotalBurnedRegen()` | `db.ts` | `get_burn_status` tool |
| `getPoolRunBatches()` | `db.ts` | `get_pool_history` tool |
| `getAttributionsByRun()` | `db.ts` | `get_pool_history` tool, `/api/v1/pool/history` |
| `getBurnLedger()` | `accounting.ts` | `/api/v1/burn/history` |
| `getPendingBurnBudget()` | `retire-subscriber.ts` | `burn-run` CLI |
| `checkOsmosisReadiness()` | `swap-and-burn.ts` | `burn-run` CLI |
| `swapAndBurn()` | `swap-and-burn.ts` | `burn-run` CLI |
| `formatSwapAndBurnResult()` | `swap-and-burn.ts` | `burn-run` CLI |

## Test plan

- [x] `npm run typecheck` — clean, no errors
- [x] `npm test` — all 49 tests pass
- [ ] Verify `get_burn_status` and `get_pool_history` appear in MCP tool list
- [ ] Verify 3 new prompts appear in MCP prompt list
- [ ] Verify `npx regen-compute burn-run --dry-run` reports pending budget and simulates
- [ ] Verify `GET /api/v1/pool/history` returns pool runs with auth
- [ ] Verify `GET /api/v1/burn/history` returns burn ledger with auth
- [ ] Verify OpenAPI spec renders at `/api/v1/openapi.json` with new endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)