### PR TITLE
add: accounting/usage REST, retirement reason tool, agent discovery docs

### DIFF
--- a/docs/agent-discovery.md
+++ b/docs/agent-discovery.md
@@ -1,0 +1,241 @@
+# Agent Discovery Endpoints
+
+Regenerative Compute exposes three machine-readable discovery endpoints that allow autonomous AI agents, orchestration platforms, and crawlers to discover capabilities without human intervention.
+
+All three are served by the web server (`npx regen-compute serve`) and require no authentication.
+
+## Overview
+
+| Endpoint | Protocol | Purpose |
+|----------|----------|---------|
+| `/.well-known/mcp/server-card.json` | MCP | Describes the MCP server — tools, transport, install command |
+| `/.well-known/agent.json` | Google A2A | Describes agent skills, auth schemes, input/output modes |
+| `/.well-known/agents.json` | Custom | Describes multi-step API workflows for orchestration agents |
+
+## MCP Server Card
+
+**URL**: `/.well-known/mcp/server-card.json`
+
+Describes this MCP server for tools that scan for available MCP servers. Follows the emerging MCP server card convention.
+
+### Payload
+
+```json
+{
+  "name": "regen-compute",
+  "version": "0.3.4",
+  "description": "Ecological accountability for AI compute — retire verified ecocredits on Regen Network",
+  "transport": ["stdio"],
+  "install": "npx regen-compute",
+  "homepage": "https://compute.regen.network",
+  "repository": "https://github.com/regen-network/regen-compute",
+  "npm": "https://www.npmjs.com/package/regen-compute",
+  "capabilities": {
+    "tools": true,
+    "prompts": true,
+    "resources": false
+  },
+  "tools": [
+    "estimate_session_footprint",
+    "estimate_monthly_footprint",
+    "browse_available_credits",
+    "retire_credits",
+    "get_retirement_certificate",
+    "get_impact_summary",
+    "check_subscription_status"
+  ],
+  "credit_types": [
+    "carbon",
+    "biodiversity",
+    "umbrella_species",
+    "marine_biodiversity",
+    "regenerative_grazing"
+  ]
+}
+```
+
+### How agents use it
+
+1. Agent discovers the server card at a well-known URL
+2. Reads `transport: ["stdio"]` to know this is a local MCP server
+3. Reads `install: "npx regen-compute"` to auto-install
+4. Reads `tools` array to understand what capabilities are available
+5. Reads `capabilities` to know whether prompts/resources are supported
+
+## Google A2A Agent Card
+
+**URL**: `/.well-known/agent.json`
+
+Follows the [Google Agent-to-Agent (A2A) protocol](https://google.github.io/A2A/) specification. Describes what this agent can do and how to authenticate.
+
+### Payload
+
+```json
+{
+  "name": "Regenerative Compute",
+  "description": "Retire verified ecological credits on behalf of AI compute usage on Regen Network",
+  "url": "https://compute.regen.network",
+  "version": "1.0",
+  "provider": {
+    "organization": "Regen Network Development",
+    "url": "https://regen.network"
+  },
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false
+  },
+  "skills": [
+    {
+      "id": "estimate_footprint",
+      "name": "Estimate AI Footprint",
+      "description": "Estimate the ecological footprint of an AI session based on duration and tool calls"
+    },
+    {
+      "id": "browse_credits",
+      "name": "Browse Ecological Credits",
+      "description": "View available carbon, biodiversity, and species stewardship credits with live pricing"
+    },
+    {
+      "id": "retire_credits",
+      "name": "Retire Ecological Credits",
+      "description": "Permanently retire verified ecological credits on Regen Ledger"
+    },
+    {
+      "id": "get_certificate",
+      "name": "Get Retirement Certificate",
+      "description": "Retrieve on-chain proof of credit retirement with verifiable transaction hash"
+    },
+    {
+      "id": "check_subscription",
+      "name": "Check Subscription Status",
+      "description": "Check subscriber status, cumulative impact, and referral link"
+    }
+  ],
+  "authentication": {
+    "schemes": ["bearer", "x402"],
+    "credentials_url": "https://compute.regen.network",
+    "description": "API key via subscription, or x402 per-request payment (USDC on Base). x402-enabled agents can pay automatically."
+  },
+  "defaultInputModes": ["application/json"],
+  "defaultOutputModes": ["application/json"]
+}
+```
+
+### How agents use it
+
+1. Orchestration agent fetches `/.well-known/agent.json` from any URL
+2. Reads `skills` to decide if this agent is useful for the current task
+3. Reads `authentication.schemes` — `bearer` for API key, `x402` for automatic payment
+4. For `x402`, the agent can pay per-request without pre-provisioning (see [x402-agent-flow.md](x402-agent-flow.md))
+5. Uses the REST API (`/api/v1/`) to invoke skills programmatically
+
+## Multi-Step Agent Flows
+
+**URL**: `/.well-known/agents.json`
+
+Custom endpoint that describes complete API workflows. Designed for orchestration agents that need to chain multiple API calls to accomplish a goal.
+
+### Payload
+
+```json
+{
+  "version": "1.0",
+  "name": "Regenerative Compute",
+  "description": "Ecological accountability for AI compute via verified credit retirement on Regen Network",
+  "api_base": "https://compute.regen.network/api/v1",
+  "openapi": "https://compute.regen.network/api/v1/openapi.json",
+  "authentication": {
+    "type": "bearer",
+    "header": "Authorization"
+  },
+  "flows": [
+    {
+      "id": "offset_ai_session",
+      "name": "Offset AI Session",
+      "description": "Estimate footprint, browse credits, retire, get certificate",
+      "steps": [
+        {
+          "method": "GET",
+          "path": "/footprint?session_minutes={minutes}&tool_calls={calls}",
+          "description": "Estimate session footprint"
+        },
+        {
+          "method": "GET",
+          "path": "/credits?type=all",
+          "description": "Browse available credits"
+        },
+        {
+          "method": "POST",
+          "path": "/retire",
+          "body": { "credit_class": "string", "quantity": "number" },
+          "description": "Retire ecological credits"
+        },
+        {
+          "method": "GET",
+          "path": "/certificates/{nodeId}",
+          "description": "Get retirement certificate"
+        }
+      ]
+    },
+    {
+      "id": "check_impact",
+      "name": "Check Ecological Impact",
+      "description": "View subscription status and network-wide impact",
+      "steps": [
+        {
+          "method": "GET",
+          "path": "/subscription",
+          "description": "Check subscription and cumulative impact"
+        },
+        {
+          "method": "GET",
+          "path": "/impact",
+          "description": "View Regen Network aggregate stats"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### How agents use it
+
+1. Orchestration agent fetches `/.well-known/agents.json`
+2. Reads `flows` to find a matching workflow (e.g., "offset_ai_session")
+3. Executes `steps` sequentially, substituting parameters from previous step results
+4. Uses `api_base` to construct full URLs and `openapi` to validate request/response schemas
+5. Authentication via `Authorization: Bearer <api_key>` header on all requests
+
+## Discovery Flow
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Server as Regenerative Compute
+
+    Note over Agent,Server: Zero-config discovery
+
+    Agent->>Server: GET /.well-known/agent.json
+    Server-->>Agent: A2A card (skills, auth schemes)
+
+    alt Agent has API key
+        Agent->>Server: GET /api/v1/subscription<br/>Authorization: Bearer rfa_...
+        Server-->>Agent: Subscription status
+    else Agent supports x402
+        Agent->>Server: GET /api/v1/credits
+        Server-->>Agent: 402 + payment requirements
+        Note over Agent: Send USDC, retry with proof
+    else Agent needs workflow
+        Agent->>Server: GET /.well-known/agents.json
+        Server-->>Agent: Multi-step flows
+        Note over Agent: Execute "offset_ai_session" flow
+    end
+```
+
+## Source
+
+- Server card: [`src/server/index.ts`](../src/server/index.ts) (line 166)
+- A2A card: [`src/server/index.ts`](../src/server/index.ts) (line 197)
+- Flows: [`src/server/index.ts`](../src/server/index.ts) (line 231)
+- x402 payment protocol: [`docs/x402-agent-flow.md`](x402-agent-flow.md)
+- OpenAPI spec: [`src/server/openapi.json`](../src/server/openapi.json)

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { getRetirementCertificate } from "./tools/certificates.js";
 import { getImpactSummary } from "./tools/impact.js";
 import { retireCredits } from "./tools/retire.js";
 import { checkSubscriptionStatus } from "./tools/subscription.js";
+import { getRetirementReasonTool } from "./tools/retirement-reason.js";
 import { loadConfig, isWalletConfigured } from "./config.js";
 import {
   fetchRegistry,
@@ -372,6 +373,31 @@ server.tool(
   },
   async () => {
     return checkSubscriptionStatus();
+  }
+);
+
+// Tool: Show the JSON-LD structured retirement reason format
+server.tool(
+  "get_retirement_reason",
+  "Shows the structured JSON-LD retirement reason format that gets written on-chain for every credit retirement. Use this when a developer or agent wants to understand the on-chain attribution schema, see example payloads, or build a custom reason string. Includes methodology references, version tracking, and source attribution.",
+  {
+    source: z
+      .enum(["mcp_tool", "subscription"])
+      .optional()
+      .describe("Source context for the retirement reason"),
+    note: z
+      .string()
+      .optional()
+      .describe("Human-readable note to include in the reason"),
+  },
+  {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  async ({ source, note }) => {
+    return getRetirementReasonTool(source, note);
   }
 );
 

--- a/src/server/api-routes.ts
+++ b/src/server/api-routes.ts
@@ -43,6 +43,7 @@ import { verifyPayment, getEvmChainCoingeckoId } from "../services/crypto-verify
 import { toUsdCents } from "../services/crypto-price.js";
 import { deriveSubscriberAddress } from "../services/subscriber-wallet.js";
 import { calculateNetAfterStripe, retireForSubscriber } from "../services/retire-subscriber.js";
+import { getFinancialSummary } from "../services/accounting.js";
 
 // Credit type abbreviation to human-readable name
 const CREDIT_TYPE_NAMES: Record<string, string> = {
@@ -728,6 +729,91 @@ export function createApiRoutes(
       subscribe_url: subscribeUrl,
       manage_url: `${baseUrl}/manage?email=${encodeURIComponent(user.email ?? "")}`,
     });
+  });
+
+  // --- GET /api/v1/accounting ---
+  router.get("/api/v1/accounting", (req: Request, res: Response) => {
+    const user = getUser(req);
+    if (!user) return;
+
+    try {
+      const summary = getFinancialSummary(db);
+      res.json(summary);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      apiError(res, 500, "INTERNAL_ERROR", `Failed to generate accounting summary: ${msg}`);
+    }
+  });
+
+  // --- GET /api/v1/usage ---
+  router.get("/api/v1/usage", (req: Request, res: Response) => {
+    const user = getUser(req);
+    if (!user) return;
+
+    const limit = Math.min(parseInt((req.query.limit as string) || "100", 10), 500);
+    const endpoint = (req.query.endpoint as string) || undefined;
+
+    try {
+      // Usage for the authenticated user only
+      let query = "SELECT endpoint, method, status_code, response_time_ms, created_at FROM api_usage WHERE user_id = ?";
+      const params: unknown[] = [user.id];
+
+      if (endpoint) {
+        query += " AND endpoint = ?";
+        params.push(endpoint);
+      }
+
+      query += " ORDER BY created_at DESC LIMIT ?";
+      params.push(limit);
+
+      const rows = db.prepare(query).all(...params) as Array<{
+        endpoint: string; method: string; status_code: number;
+        response_time_ms: number | null; created_at: string;
+      }>;
+
+      // Aggregate stats for this user
+      const statsRow = db.prepare(`
+        SELECT
+          COUNT(*) AS total_requests,
+          AVG(response_time_ms) AS avg_response_ms,
+          MIN(created_at) AS first_request,
+          MAX(created_at) AS last_request
+        FROM api_usage WHERE user_id = ?
+      `).get(user.id) as {
+        total_requests: number; avg_response_ms: number | null;
+        first_request: string | null; last_request: string | null;
+      };
+
+      // Per-endpoint breakdown
+      const endpointBreakdown = db.prepare(`
+        SELECT endpoint, method, COUNT(*) AS count, AVG(response_time_ms) AS avg_ms
+        FROM api_usage WHERE user_id = ?
+        GROUP BY endpoint, method ORDER BY count DESC
+      `).all(user.id) as Array<{
+        endpoint: string; method: string; count: number; avg_ms: number | null;
+      }>;
+
+      res.json({
+        stats: {
+          total_requests: statsRow.total_requests,
+          avg_response_ms: statsRow.avg_response_ms !== null
+            ? Math.round(statsRow.avg_response_ms)
+            : null,
+          first_request: statsRow.first_request,
+          last_request: statsRow.last_request,
+        },
+        endpoints: endpointBreakdown.map((e) => ({
+          endpoint: e.endpoint,
+          method: e.method,
+          count: e.count,
+          avg_response_ms: e.avg_ms !== null ? Math.round(e.avg_ms) : null,
+        })),
+        recent: rows,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      apiError(res, 500, "INTERNAL_ERROR", `Failed to fetch usage data: ${msg}`);
+    }
   });
 
   return router;

--- a/src/server/openapi.json
+++ b/src/server/openapi.json
@@ -181,6 +181,70 @@
         }
       }
     },
+    "/accounting": {
+      "get": {
+        "operationId": "getAccounting",
+        "summary": "Get financial accounting summary",
+        "description": "Returns a complete financial summary including revenue, Stripe fees, credit/burn/ops allocation splits, credit spending, REGEN burns, subscriber stats, and monthly breakdown. Previously CLI-only.",
+        "responses": {
+          "200": {
+            "description": "Financial accounting summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountingResponse"
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/usage": {
+      "get": {
+        "operationId": "getUsage",
+        "summary": "Get your API usage stats",
+        "description": "Returns API usage statistics for the authenticated user, including per-endpoint breakdown and recent request log. Scoped to the calling API key only.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of recent requests to return (max 500)",
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "endpoint",
+            "in": "query",
+            "description": "Filter recent requests by endpoint path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "API usage statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UsageResponse"
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
     "/impact": {
       "get": {
         "operationId": "getImpact",
@@ -368,6 +432,86 @@
               "properties": {
                 "abbreviation": { "type": "string" },
                 "name": { "type": "string" }
+              }
+            }
+          }
+        }
+      },
+      "AccountingResponse": {
+        "type": "object",
+        "properties": {
+          "totalGrossRevenueCents": { "type": "integer" },
+          "totalStripeFeesCents": { "type": "integer" },
+          "totalNetRevenueCents": { "type": "integer" },
+          "totalCreditsBudgetCents": { "type": "integer" },
+          "totalBurnBudgetCents": { "type": "integer" },
+          "totalOpsBudgetCents": { "type": "integer" },
+          "totalCreditsSpentCents": { "type": "integer" },
+          "totalCreditsUnspentCents": { "type": "integer" },
+          "totalCreditsRetired": { "type": "number" },
+          "avgCostPerCredit": { "type": "integer", "nullable": true },
+          "totalBurnsPendingCents": { "type": "integer" },
+          "totalBurnsExecutedCents": { "type": "integer" },
+          "totalRegenBurned": { "type": "number" },
+          "totalBurnTxCount": { "type": "integer" },
+          "avgRegenPriceAtBurn": { "type": "number", "nullable": true },
+          "totalOpsAvailableCents": { "type": "integer" },
+          "activeSubscriberCount": { "type": "integer" },
+          "totalRetirementCount": { "type": "integer" },
+          "monthlyRecurringRevenueCents": { "type": "integer" },
+          "monthlyBreakdown": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "month": { "type": "string" },
+                "grossRevenueCents": { "type": "integer" },
+                "netRevenueCents": { "type": "integer" },
+                "creditsBudgetCents": { "type": "integer" },
+                "creditsSpentCents": { "type": "integer" },
+                "burnBudgetCents": { "type": "integer" },
+                "opsBudgetCents": { "type": "integer" },
+                "creditsRetired": { "type": "number" },
+                "retirementCount": { "type": "integer" }
+              }
+            }
+          }
+        }
+      },
+      "UsageResponse": {
+        "type": "object",
+        "properties": {
+          "stats": {
+            "type": "object",
+            "properties": {
+              "total_requests": { "type": "integer" },
+              "avg_response_ms": { "type": "integer", "nullable": true },
+              "first_request": { "type": "string", "nullable": true },
+              "last_request": { "type": "string", "nullable": true }
+            }
+          },
+          "endpoints": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "endpoint": { "type": "string" },
+                "method": { "type": "string" },
+                "count": { "type": "integer" },
+                "avg_response_ms": { "type": "integer", "nullable": true }
+              }
+            }
+          },
+          "recent": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "endpoint": { "type": "string" },
+                "method": { "type": "string" },
+                "status_code": { "type": "integer" },
+                "response_time_ms": { "type": "integer", "nullable": true },
+                "created_at": { "type": "string" }
               }
             }
           }

--- a/src/tools/retirement-reason.ts
+++ b/src/tools/retirement-reason.ts
@@ -1,0 +1,109 @@
+/**
+ * MCP tool: get_retirement_reason
+ *
+ * Exposes the JSON-LD structured retirement reason format from
+ * services/retirement-reason.ts. Shows developers exactly what
+ * gets written on-chain for any retirement.
+ */
+
+import { buildRetirementReason } from "../services/retirement-reason.js";
+
+export async function getRetirementReasonTool(
+  source?: "mcp_tool" | "subscription",
+  note?: string,
+  subscriberId?: number,
+  period?: string,
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+}> {
+  try {
+    // Build example reasons for each source type
+    const mcpExample = buildRetirementReason({
+      note: note || "Regenerative contribution via Regenerative Compute",
+      source: "mcp_tool",
+    });
+    const subExample = buildRetirementReason({
+      note: "Monthly ecological contribution",
+      subscriberId: subscriberId || 42,
+      period: period || new Date().toISOString().slice(0, 7),
+      source: "subscription",
+    });
+
+    // Build a custom one if source was specified
+    let customExample: string | null = null;
+    if (source || note) {
+      customExample = buildRetirementReason({
+        note,
+        subscriberId,
+        period,
+        source,
+      });
+    }
+
+    const lines: string[] = [
+      `## Structured Retirement Reason Format`,
+      ``,
+      `Every credit retirement on Regen Network includes a \`reason\` field written on-chain.`,
+      `Regenerative Compute uses a JSON-LD-compatible structure for machine-readable attribution.`,
+      ``,
+      `### Schema`,
+      ``,
+      `| Field | Type | Description |`,
+      `|-------|------|-------------|`,
+      `| \`@context\` | string | JSON-LD context URL (\`https://schema.regen.network/v1\`) |`,
+      `| \`type\` | string | Always \`ComputeFootprintRetirement\` |`,
+      `| \`tool\` | string | Always \`regen-compute\` |`,
+      `| \`version\` | string | Package version at time of retirement |`,
+      `| \`methodology\` | string | Footprint estimation methodology reference |`,
+      `| \`uncertaintyRange\` | string | Acknowledged uncertainty range (\`10x\`) |`,
+      `| \`note\` | string? | Human-readable context (subscriber name, purpose) |`,
+      `| \`period\` | string? | Billing period (\`YYYY-MM\`) for subscription retirements |`,
+      `| \`source\` | string? | \`mcp_tool\` for direct retirements, \`subscription\` for scheduled |`,
+      ``,
+      `### Example: MCP Tool Retirement`,
+      ``,
+      "```json",
+      JSON.stringify(JSON.parse(mcpExample), null, 2),
+      "```",
+      ``,
+      `### Example: Subscription Retirement`,
+      ``,
+      "```json",
+      JSON.stringify(JSON.parse(subExample), null, 2),
+      "```",
+    ];
+
+    if (customExample) {
+      lines.push(
+        ``,
+        `### Your Custom Reason`,
+        ``,
+        "```json",
+        JSON.stringify(JSON.parse(customExample), null, 2),
+        "```",
+      );
+    }
+
+    lines.push(
+      ``,
+      `### How It Works`,
+      ``,
+      `1. The \`reason\` string is passed to \`MsgRetire\` or \`MsgSend\` (retiredAmount) on Regen Ledger`,
+      `2. It is stored permanently on-chain in the retirement record`,
+      `3. Indexers and the claims engine can parse the JSON for structured attribution`,
+      `4. Older consumers that treat \`reason\` as plain text see valid JSON (backward-compatible)`,
+      ``,
+      `The \`methodology\` field references Luccioni et al. 2023 ("Power Hungry Processing")`,
+      `and IEA 2024 data on AI energy consumption. The \`uncertaintyRange: "10x"\` acknowledges`,
+      `that heuristic estimates may be off by an order of magnitude — this is regenerative`,
+      `contribution, not precise carbon accounting.`,
+    );
+
+    return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text" as const, text: `Error building retirement reason: ${message}` }],
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Surfaces the last unexposed service-layer capabilities and adds critical documentation for autonomous agent integrators. Does not duplicate anything in PRs #113–#116.

**5 additions:**
- 2 REST endpoints (`/api/v1/accounting`, `/api/v1/usage`)
- 1 MCP tool (`get_retirement_reason`)
- 1 documentation file (`docs/agent-discovery.md`)
- 2 OpenAPI schema entries (`AccountingResponse`, `UsageResponse`)

## Changes in detail

### REST: `GET /api/v1/accounting`

**Modified**: `src/server/api-routes.ts`

Calls `getFinancialSummary(db)` from `services/accounting.ts` — the same function the `regen-compute accounting` CLI subcommand uses (#114). Returns the raw `FinancialSummary` object as JSON:

- Revenue: gross, Stripe fees, net
- Allocation: credits budget, burn budget, ops budget (with % splits)
- Credit spending: budget vs actual, total credits retired, avg cost per credit
- REGEN burns: pending accumulator, executed burns, total REGEN burned, avg price
- Subscribers: active count, total retirements, MRR
- Monthly breakdown: per-month gross/net/credits/burn/ops/retired

Previously this data was CLI-only. Now accessible via REST for dashboards and monitoring.

### REST: `GET /api/v1/usage?limit=100&endpoint=/retire`

**Modified**: `src/server/api-routes.ts`

Queries the `api_usage` table **scoped to the authenticated user's API key only** — developers can see their own usage but not anyone else's. Returns:

- `stats`: total requests, average response time, first/last request timestamps
- `endpoints[]`: per-endpoint breakdown with counts and avg response time
- `recent[]`: individual request log (endpoint, method, status_code, response_time_ms, created_at)

Query params: `?limit=N` (max 500), `?endpoint=/retire` (filter by path).

### MCP tool: `get_retirement_reason`

**New file**: `src/tools/retirement-reason.ts`

Calls `buildRetirementReason()` from `services/retirement-reason.ts` with various option combinations. Returns:

- Schema table documenting every field (`@context`, `type`, `tool`, `version`, `methodology`, `uncertaintyRange`, `note`, `period`, `source`)
- Example payload for `mcp_tool` source (direct retirement)
- Example payload for `subscription` source (scheduled retirement)
- Custom payload if `source` or `note` parameters are provided
- Explanation of how the reason field flows to on-chain `MsgRetire`/`MsgSend`

Accepts optional `source` and `note` parameters to generate custom examples.

### Documentation: `docs/agent-discovery.md`

**New file**: `docs/agent-discovery.md`

Documents the three machine-readable discovery endpoints already served by the web server:

| Endpoint | Protocol | What it advertises |
|----------|----------|--------------------|
| `/.well-known/mcp/server-card.json` | MCP convention | Tools, transport, install command, capabilities |
| `/.well-known/agent.json` | Google A2A | Skills, auth schemes (bearer + x402), provider info |
| `/.well-known/agents.json` | Custom | Multi-step API workflows with parameterized steps |

Each section includes the full JSON payload (copied from `src/server/index.ts` lines 166–264) and a "How agents use it" explanation. Ends with a mermaid sequence diagram showing the zero-config discovery flow and links to `x402-agent-flow.md` (#113).

### OpenAPI spec

**Modified**: `src/server/openapi.json`

- Added paths: `/accounting`, `/usage`
- Added schemas: `AccountingResponse` (mirrors the `FinancialSummary` interface exactly — 20 fields + `monthlyBreakdown[]`), `UsageResponse` (stats, endpoints, recent)

## Files changed

| File | Change |
|------|--------|
| `src/tools/retirement-reason.ts` | **New** — get_retirement_reason MCP tool |
| `docs/agent-discovery.md` | **New** — discovery endpoint documentation |
| `src/index.ts` | 1 import, 1 tool registration |
| `src/server/api-routes.ts` | 1 import, 2 REST endpoints |
| `src/server/openapi.json` | 2 path entries, 2 response schemas |

## Service functions called (all pre-existing)

| Function | Source | Called by |
|----------|--------|----------|
| `getFinancialSummary()` | `accounting.ts` | `/api/v1/accounting` |
| `recordApiUsage()` | `db.ts` | Already called by auth middleware; `/api/v1/usage` reads the same table |
| `buildRetirementReason()` | `retirement-reason.ts` | `get_retirement_reason` tool |

## No overlap with existing PRs

| PR | What it added | Overlap? |
|----|--------------|----------|
| #113 | `docs/x402-agent-flow.md` | No — this PR adds `docs/agent-discovery.md` (different topic) |
| #114 | `check_supply_health` tool, `accounting`/`swap-and-burn` CLI, ecoBridge REST | No — this PR adds the REST endpoint for accounting (CLI existed, REST didn't) |
| #115 | `get_burn_status`/`get_pool_history` tools, prompts, `burn-run` CLI, pool/burn REST | No overlap |
| #116 | `get_regen_price`/`verify_payment`/`get_community_goals`, community/scheduled REST, README | No overlap |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — all 49 tests pass
- [ ] Verify `GET /api/v1/accounting` returns full `FinancialSummary` JSON with auth
- [ ] Verify `GET /api/v1/usage` returns only the calling user's usage data
- [ ] Verify `GET /api/v1/usage?endpoint=/retire` filters correctly
- [ ] Verify `get_retirement_reason` MCP tool shows schema + examples
- [ ] Verify `get_retirement_reason` with `source=subscription&note=test` shows custom payload
- [ ] Verify `docs/agent-discovery.md` mermaid diagram renders on GitHub
- [ ] Verify OpenAPI spec at `/api/v1/openapi.json` includes `/accounting` and `/usage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)