### PR TITLE
Rate-limit Stripe-facing endpoints (audit S2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,3 +101,14 @@ ECOBRIDGE_CACHE_TTL_MS=60000
 # Existing API key auth continues to work alongside x402.
 # X402_ENABLED=false
 # X402_FACILITATOR_URL=https://x402.org/facilitator
+
+# --- Rate Limiting (Stripe-facing endpoints) ---
+# Per-IP limits on unauthenticated checkout/subscribe/manage/webhook endpoints.
+# REGEN_API_RATE_LIMIT (per-API-key, applied in api-routes) is unaffected.
+# REGEN_RATELIMIT_CHECKOUT_PER_MIN=20
+# REGEN_RATELIMIT_WEBHOOK_PER_MIN=600
+
+# Trust reverse-proxy headers (X-Forwarded-For) when computing req.ip.
+# Default: 1 (trust one hop — typical for nginx → node). Set to a higher
+# integer for additional proxy layers, or to "false" to disable entirely.
+# REGEN_TRUST_PROXY=1

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,10 @@
         "@cosmjs/stargate": "^0.32.4",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@regen-network/api": "^1.0.0-alpha8",
-        "@x402/core": "^2.8.0",
-        "@x402/evm": "^2.8.0",
-        "@x402/express": "^2.8.0",
         "better-sqlite3": "^12.6.2",
         "ethers": "^6.16.0",
         "express": "^5.2.1",
+        "express-rate-limit": "8.4.1",
         "helmet": "^8.1.0",
         "osmojs": "^16.15.0",
         "stripe": "^20.3.1"
@@ -700,18 +698,6 @@
         }
       }
     },
-    "node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@noble/curves": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
@@ -1373,100 +1359,6 @@
         "win32"
       ]
     },
-    "node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip32": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
-      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "~1.9.0",
-        "@noble/hashes": "~1.8.0",
-        "@scure/base": "~1.2.5"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip32/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip39": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
-      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "~1.8.0",
-        "@scure/base": "~1.2.5"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@spruceid/siwe-parser": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.1.2.tgz",
-      "integrity": "sha512-d/r3S1LwJyMaRAKQ0awmo9whfXeE88Qt00vRj91q5uv5ATtWIQEGJ67Yr5eSZw5zp1/fZCXZYuEckt8lSkereQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/hashes": "^1.1.2",
-        "apg-js": "^4.3.0",
-        "uri-js": "^4.4.1",
-        "valid-url": "^1.0.9"
-      }
-    },
-    "node_modules/@stablelib/binary": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
-      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/int": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/int": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
-      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==",
-      "license": "MIT"
-    },
-    "node_modules/@stablelib/random": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
-      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/wipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
-      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
-      "license": "MIT"
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1723,145 +1615,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@x402/core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.8.0.tgz",
-      "integrity": "sha512-ppsvSzyWzlqG+26dcNzOXo/YLaHreWc3lmdv9W81mEhLDWMdPpiGyRjSUyO9BQFuQJMQppvqA7ujUbLE/EaDkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "zod": "^3.24.2"
-      }
-    },
-    "node_modules/@x402/core/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@x402/evm": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@x402/evm/-/evm-2.8.0.tgz",
-      "integrity": "sha512-/w1WvoXIZdaJcmvR8p9/ow1n8GjNWeeVnpoorjfLv2oBbT06r33clcfYwhH/COJp/K0aOvmol0elx5h2IQCnOA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@x402/core": "~2.8.0",
-        "viem": "^2.39.3",
-        "zod": "^3.24.2"
-      }
-    },
-    "node_modules/@x402/evm/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@x402/express": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@x402/express/-/express-2.8.0.tgz",
-      "integrity": "sha512-N+lQWuwGKRWnpXVICkoHA8IncO6cfs/ZEzdhW839vOoFMTj4JiqyL6MUw4WMpmpJ4D+ZFe1eCTnYY5A7iaMB7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@x402/core": "~2.8.0",
-        "@x402/extensions": "~2.8.0",
-        "viem": "^2.39.3",
-        "zod": "^3.24.2"
-      },
-      "peerDependencies": {
-        "@x402/paywall": "^2.8.0",
-        "express": "^4.0.0 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@x402/paywall": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@x402/express/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@x402/extensions": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@x402/extensions/-/extensions-2.8.0.tgz",
-      "integrity": "sha512-3VHY7cjyYkI8JMbF81Soh9gEcFFekXiGr+71Jp39lOzIGmX67Q8+2hkLiIu5laKoaz0vi2gnaqTYESADRhO9DA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.9.0",
-        "@scure/base": "^1.2.6",
-        "@x402/core": "~2.8.0",
-        "ajv": "^8.17.1",
-        "jose": "^5.9.6",
-        "siwe": "^2.3.2",
-        "tweetnacl": "^1.0.3",
-        "viem": "^2.43.5",
-        "zod": "^3.24.2"
-      }
-    },
-    "node_modules/@x402/extensions/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@x402/extensions/node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/@x402/extensions/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/abitype": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
-      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/wevm"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4",
-        "zod": "^3.22.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1913,12 +1666,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/apg-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.4.0.tgz",
-      "integrity": "sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2566,12 +2313,6 @@
         }
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
-    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -2656,12 +2397,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -3088,9 +2829,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3121,21 +2862,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ws": "*"
-      }
-    },
-    "node_modules/isows": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
-      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
       "license": "MIT",
       "peerDependencies": {
         "ws": "*"
@@ -3476,57 +3202,6 @@
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/ox": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.7.tgz",
-      "integrity": "sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.2.3",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ox/node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
-      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-      "license": "MIT"
-    },
-    "node_modules/ox/node_modules/@noble/curves": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
-      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3700,15 +3375,6 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -4099,21 +3765,6 @@
         "simple-concat": "^1.0.0"
       }
     },
-    "node_modules/siwe": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.3.2.tgz",
-      "integrity": "sha512-aSf+6+Latyttbj5nMu6GF3doMfv2UYj83hhwZgUF20ky6fTS83uVhkQABdIVnEuS8y1bBdk7p6ltb9SmlhTTlA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@spruceid/siwe-parser": "^2.1.2",
-        "@stablelib/random": "^1.0.1",
-        "uri-js": "^4.4.1",
-        "valid-url": "^1.0.9"
-      },
-      "peerDependencies": {
-        "ethers": "^5.6.8 || ^6.0.8"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4310,12 +3961,6 @@
         "node": "*"
       }
     },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "license": "Unlicense"
-    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -4334,7 +3979,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4359,25 +4004,11 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/valid-url": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -4386,72 +4017,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/viem": {
-      "version": "2.47.6",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.6.tgz",
-      "integrity": "sha512-zExmbI99NGvMdYa7fmqSTLgkwh48dmhgEqFrUgkpL4kfG4XkVefZ8dZqIKVUhZo6Uhf0FrrEXOsHm9LUyIvI2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "1.8.0",
-        "@scure/bip32": "1.7.0",
-        "@scure/bip39": "1.6.0",
-        "abitype": "1.2.3",
-        "isows": "1.0.7",
-        "ox": "0.14.7",
-        "ws": "8.18.3"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/viem/node_modules/@noble/curves": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
-      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/viem/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "better-sqlite3": "^12.6.2",
     "ethers": "^6.16.0",
     "express": "^5.2.1",
+    "express-rate-limit": "8.4.1",
     "helmet": "^8.1.0",
     "osmojs": "^16.15.0",
     "stripe": "^20.3.1"

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import express from "express";
+import type { AddressInfo } from "node:net";
+import { createCheckoutLimiter, createWebhookLimiter } from "../server/rate-limit.js";
+
+function withApp(setup: (app: express.Express) => void) {
+  return new Promise<{ url: string; close: () => Promise<void> }>((resolve) => {
+    const app = express();
+    app.set("trust proxy", 1);
+    setup(app);
+    const server = app.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+describe("rate-limit middleware", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.REGEN_RATELIMIT_CHECKOUT_PER_MIN = "3";
+    process.env.REGEN_RATELIMIT_WEBHOOK_PER_MIN = "5";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("checkout limiter allows up to N requests then returns 429", async () => {
+    const app = await withApp((a) => {
+      a.post("/subscribe", createCheckoutLimiter(), (_req, res) => res.json({ ok: true }));
+    });
+
+    try {
+      const send = () => fetch(`${app.url}/subscribe`, { method: "POST" });
+      const r1 = await send();
+      const r2 = await send();
+      const r3 = await send();
+      const r4 = await send();
+      expect(r1.status).toBe(200);
+      expect(r2.status).toBe(200);
+      expect(r3.status).toBe(200);
+      expect(r4.status).toBe(429);
+      const body = await r4.json();
+      expect(body.error).toMatch(/too many/i);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("webhook limiter has a separate, higher budget", async () => {
+    const app = await withApp((a) => {
+      a.post("/webhook", createWebhookLimiter(), (_req, res) => res.json({ ok: true }));
+    });
+
+    try {
+      const send = () => fetch(`${app.url}/webhook`, { method: "POST" });
+      // 5 allowed, 6th blocked
+      for (let i = 0; i < 5; i++) {
+        const r = await send();
+        expect(r.status).toBe(200);
+      }
+      const r6 = await send();
+      expect(r6.status).toBe(429);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("emits a RateLimit-* header (draft-7 policy/limit)", async () => {
+    const app = await withApp((a) => {
+      a.post("/subscribe", createCheckoutLimiter(), (_req, res) => res.json({ ok: true }));
+    });
+    try {
+      const r = await fetch(`${app.url}/subscribe`, { method: "POST" });
+      // draft-7 emits a single combined "RateLimit" header (e.g. "limit=3, remaining=2, reset=60")
+      // and a "RateLimit-Policy" header. Either is sufficient evidence the limiter ran.
+      const combined = r.headers.get("ratelimit");
+      const policy = r.headers.get("ratelimit-policy");
+      expect(combined ?? policy).toBeTruthy();
+      if (combined) expect(combined).toMatch(/limit=3/);
+      if (policy) expect(policy).toMatch(/3/);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -47,6 +47,15 @@ export function startServer(options: { port?: number; dbPath?: string } = {}) {
 
   const app = express();
 
+  // Trust the reverse proxy (e.g. nginx) so req.ip reflects the real client.
+  // Required for per-IP rate limiting to work correctly in production. Set
+  // REGEN_TRUST_PROXY="false" to disable, or to a number to trust N hops.
+  const trustProxyEnv = process.env.REGEN_TRUST_PROXY;
+  if (trustProxyEnv !== "false") {
+    const hops = trustProxyEnv ? Number.parseInt(trustProxyEnv, 10) : NaN;
+    app.set("trust proxy", Number.isFinite(hops) && hops > 0 ? hops : 1);
+  }
+
   // Agent view middleware — intercepts ?view=agent on any page, mount first
   const agentViewRoutes = createAgentViewRoutes(baseUrl);
   app.use(agentViewRoutes);

--- a/src/server/rate-limit.ts
+++ b/src/server/rate-limit.ts
@@ -1,0 +1,55 @@
+/**
+ * Rate-limit middleware for Stripe-facing endpoints.
+ *
+ * The API endpoints under /api are already rate-limited per API key in
+ * api-routes.ts. This module adds per-IP limiting on the unauthenticated,
+ * Stripe-adjacent endpoints (checkout, subscribe, manage, cancel, webhook),
+ * so a single IP cannot hammer Stripe Checkout Session creation or replay
+ * webhook traffic faster than the upstream can absorb.
+ *
+ * Limits are configurable via env:
+ *   REGEN_RATELIMIT_CHECKOUT_PER_MIN   (default 20)
+ *   REGEN_RATELIMIT_WEBHOOK_PER_MIN    (default 600 — Stripe bursts)
+ */
+
+import rateLimit, { type RateLimitRequestHandler } from "express-rate-limit";
+
+const ONE_MINUTE_MS = 60_000;
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/**
+ * Limiter for user-initiated checkout / subscription / portal endpoints.
+ * Applied per IP. Default: 20 req/min/IP.
+ */
+export function createCheckoutLimiter(): RateLimitRequestHandler {
+  return rateLimit({
+    windowMs: ONE_MINUTE_MS,
+    limit: envInt("REGEN_RATELIMIT_CHECKOUT_PER_MIN", 20),
+    standardHeaders: "draft-7",
+    legacyHeaders: false,
+    message: { error: "Too many requests. Please try again in a minute." },
+  });
+}
+
+/**
+ * Limiter for the Stripe webhook endpoint.
+ * Stripe bursts retries during outages, so this is intentionally generous.
+ * Signature verification + event-id idempotency are the real correctness
+ * controls; this limiter exists only to bound resource exhaustion from a
+ * spoofed source. Default: 600 req/min/IP.
+ */
+export function createWebhookLimiter(): RateLimitRequestHandler {
+  return rateLimit({
+    windowMs: ONE_MINUTE_MS,
+    limit: envInt("REGEN_RATELIMIT_WEBHOOK_PER_MIN", 600),
+    standardHeaders: "draft-7",
+    legacyHeaders: false,
+    message: { error: "Webhook rate limit exceeded." },
+  });
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -58,6 +58,7 @@ import {
   getPublicOrganizations,
 } from "./db.js";
 import { betaBannerCSS, betaBannerHTML, betaBannerJS } from "./beta-banner.js";
+import { createCheckoutLimiter, createWebhookLimiter } from "./rate-limit.js";
 import { sendWelcomeEmail, sendFirstRetirementEmail, sendRetirementReceiptEmail, sendReferralBonusEmail } from "../services/email.js";
 import { deriveSubscriberAddress, sweepSubscriberFunds } from "../services/subscriber-wallet.js";
 import { retireForSubscriber, accumulateBurnBudget, getPendingBurnBudget, markBurnExecuted, calculateNetAfterStripe, type SubscriberRetirementResult } from "../services/retire-subscriber.js";
@@ -111,6 +112,14 @@ function escapeHtml(str: string): string {
 
 export function createRoutes(stripe: Stripe | null, db: Database.Database, baseUrl: string, config?: Config): Router {
   const router = Router();
+
+  // Per-IP rate limiters for Stripe-facing endpoints. These are unauthenticated
+  // (no API key), so without limits a single IP could spam Stripe API calls or
+  // replay webhook payloads. Real correctness for /webhook still relies on
+  // signature verification + event-id idempotency below — this is just a
+  // resource-exhaustion bound.
+  const checkoutLimiter = createCheckoutLimiter();
+  const webhookLimiter = createWebhookLimiter();
 
   // --- Public routes ---
 
@@ -1787,7 +1796,7 @@ ${betaBannerJS()}
    * Creates a Stripe Checkout Session in subscription mode.
    * If a valid referral_code is provided, the subscription gets a 30-day free trial.
    */
-  router.post("/subscribe", async (req: Request, res: Response) => {
+  router.post("/subscribe", checkoutLimiter, async (req: Request, res: Response) => {
     try {
       const body = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
       const { tier, interval, email, referral_code } = body ?? {};
@@ -1865,7 +1874,7 @@ ${betaBannerJS()}
    * Body: { org_name, full_time_devs, autonomous_agents, part_time_users, amount_cents }
    * Creates organization record, then a Stripe Checkout Session for the calculated amount.
    */
-  router.post("/subscribe-org", async (req: Request, res: Response) => {
+  router.post("/subscribe-org", checkoutLimiter, async (req: Request, res: Response) => {
     try {
       const body = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
       const { org_name, full_time_devs, autonomous_agents, part_time_users, amount_cents } = body ?? {};
@@ -1993,7 +2002,7 @@ ${betaBannerJS()}
    * Body: { amount_cents: 1000, email?: "user@example.com" }
    * Returns: { url: "https://checkout.stripe.com/..." }
    */
-  router.post("/checkout", async (req: Request, res: Response) => {
+  router.post("/checkout", checkoutLimiter, async (req: Request, res: Response) => {
     try {
       const { amount_cents, email } = req.body;
 
@@ -2040,7 +2049,7 @@ ${betaBannerJS()}
    * Creates a Stripe Checkout session for a one-time boost retirement targeting a specific project.
    * Returns: { url: "https://checkout.stripe.com/..." }
    */
-  router.post("/boost-checkout", async (req: Request, res: Response) => {
+  router.post("/boost-checkout", checkoutLimiter, async (req: Request, res: Response) => {
     try {
       const { amount_cents, batch_denom, project_name } = req.body;
 
@@ -2111,7 +2120,7 @@ ${betaBannerJS()}
    * Stripe webhook handler — processes checkout.session.completed events.
    * Creates user if new, credits their balance, generates API key.
    */
-  router.post("/webhook", async (req: Request, res: Response) => {
+  router.post("/webhook", webhookLimiter, async (req: Request, res: Response) => {
     const sig = req.headers["stripe-signature"] as string;
     const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
 
@@ -2585,7 +2594,7 @@ ${betaBannerJS()}
    * Creates a Stripe Billing Portal session for subscription self-management
    * (upgrade, downgrade, cancel, update payment method) and redirects to it.
    */
-  router.get("/manage", async (req: Request, res: Response) => {
+  router.get("/manage", checkoutLimiter, async (req: Request, res: Response) => {
     try {
       const email = req.query.email as string | undefined;
 


### PR DESCRIPTION
## Summary

Closes the audit's S2-HIGH finding: `apiRateLimit:100` was configured but never wired to the Stripe-facing endpoints, leaving `/webhook`, `/checkout`, `/subscribe`, `/subscribe-org`, `/boost-checkout`, and `/manage` unprotected. The per-API-key limiter in `api-routes.ts` (used by `/debit`, etc.) is unchanged.

## What this PR does

- **`src/server/rate-limit.ts`** (new): two `express-rate-limit` middleware factories
  - `createCheckoutLimiter()` — 20 req/min/IP (default), env: `REGEN_RATELIMIT_CHECKOUT_PER_MIN`
  - `createWebhookLimiter()` — 600 req/min/IP (default), env: `REGEN_RATELIMIT_WEBHOOK_PER_MIN`. Generous on purpose: Stripe bursts retries during outages, and signature verification + event-id idempotency are the real correctness controls. This just bounds resource exhaustion from a spoofed source.
- **`src/server/routes.ts`**: applies the limiters to the six Stripe-adjacent routes.
- **`src/server/index.ts`**: enables `app.set("trust proxy", 1)` so `req.ip` reflects the real client behind nginx. Override with `REGEN_TRUST_PROXY` (integer hop count, or `"false"` to disable).
- **`.env.example`**: documents the three new env vars.
- **`src/__tests__/rate-limit.test.ts`**: 3 vitest cases — allow-then-block, separate per-limiter budget, draft-7 `RateLimit` header presence.

## Notes

- `package-lock.json` shrank because the previous lockfile had stale `@x402/*` entries left over from commit `e5a3326` (which removed those deps from `package.json` but not the lock). `npm install` cleaned them up.
- Rate-limit values picked conservatively. Easy to tune via env without redeploying logic.
- Only S2 is addressed here — happy to follow up with separate PRs for C1 (floating-point money math) or C2 (on-chain retirement idempotency) if helpful.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 52/52 passing (49 prior + 3 new)
- [x] `npm run build` — clean
- [ ] Reviewer to spot-check that the limiter values are reasonable for production traffic
- [ ] Reviewer to confirm `REGEN_TRUST_PROXY=1` matches the nginx config

Refs: `AUDIT.md` S2-HIGH

🤖 Generated with [Claude Code](https://claude.com/claude-code)