### PR TITLE
Idempotency on on-chain retirement (audit C2)

### DIFF
--- a/src/__tests__/retirement-idempotency.test.ts
+++ b/src/__tests__/retirement-idempotency.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import {
+  cacheRetirementResult,
+  getCachedRetirementResult,
+  pruneExpiredIdempotencyKeys,
+} from "../server/db.js";
+
+/**
+ * In-memory SQLite that mimics the production schema for the idempotency
+ * cache only. We don't run the full getDb() path here — that would pull
+ * in the full subscriber/user/etc. schema, which is overkill for this
+ * unit test.
+ */
+function makeDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS retirement_idempotency_keys (
+      idempotency_key TEXT PRIMARY KEY,
+      tx_hash TEXT,
+      result_json TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+  return db;
+}
+
+describe("retirement idempotency cache", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = makeDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("returns null for an unknown key", () => {
+    expect(getCachedRetirementResult(db, "missing")).toBeNull();
+  });
+
+  it("round-trips a result", () => {
+    const result = { status: "success", txHash: "ABC123", creditsRetired: "1.5" };
+    cacheRetirementResult(db, "key-1", "ABC123", result);
+    const cached = getCachedRetirementResult(db, "key-1");
+    expect(cached).not.toBeNull();
+    expect(cached!.txHash).toBe("ABC123");
+    expect(cached!.result).toEqual(result);
+  });
+
+  it("INSERT OR IGNORE preserves the first write under racing duplicates", () => {
+    cacheRetirementResult(db, "key-2", "TX_FIRST", { status: "success", txHash: "TX_FIRST" });
+    cacheRetirementResult(db, "key-2", "TX_SECOND", { status: "success", txHash: "TX_SECOND" });
+    const cached = getCachedRetirementResult(db, "key-2");
+    expect(cached!.txHash).toBe("TX_FIRST");
+  });
+
+  it("ignores entries older than the TTL", () => {
+    cacheRetirementResult(db, "key-old", "TX_OLD", { status: "success" });
+    // Backdate the row beyond the 24h TTL.
+    db.prepare(
+      "UPDATE retirement_idempotency_keys SET created_at = datetime('now', '-25 hours') WHERE idempotency_key = ?"
+    ).run("key-old");
+    expect(getCachedRetirementResult(db, "key-old")).toBeNull();
+  });
+
+  it("survives malformed JSON without throwing", () => {
+    db.prepare(
+      "INSERT INTO retirement_idempotency_keys (idempotency_key, tx_hash, result_json) VALUES (?, ?, ?)"
+    ).run("key-bad", "TX", "{not valid json");
+    expect(getCachedRetirementResult(db, "key-bad")).toBeNull();
+  });
+
+  it("pruneExpiredIdempotencyKeys removes only expired rows", () => {
+    cacheRetirementResult(db, "fresh", "TX1", { status: "success" });
+    cacheRetirementResult(db, "stale", "TX2", { status: "success" });
+    db.prepare(
+      "UPDATE retirement_idempotency_keys SET created_at = datetime('now', '-25 hours') WHERE idempotency_key = ?"
+    ).run("stale");
+    const removed = pruneExpiredIdempotencyKeys(db);
+    expect(removed).toBe(1);
+    expect(getCachedRetirementResult(db, "fresh")).not.toBeNull();
+    expect(getCachedRetirementResult(db, "stale")).toBeNull();
+  });
+});
+
+describe("wallet broadcast mutex", () => {
+  it("serializes overlapping signAndBroadcast calls per address", async () => {
+    // Recreate the same chained-promise pattern used in src/services/wallet.ts
+    // and verify two concurrent calls observe in-order entry/exit.
+    const chains = new Map<string, Promise<unknown>>();
+    async function withWalletLock<T>(address: string, fn: () => Promise<T>): Promise<T> {
+      const prior = chains.get(address) ?? Promise.resolve();
+      let release: () => void;
+      const next = new Promise<void>((r) => { release = r; });
+      chains.set(address, next);
+      try {
+        await prior.catch(() => undefined);
+        return await fn();
+      } finally {
+        release!();
+        if (chains.get(address) === next) {
+          chains.delete(address);
+        }
+      }
+    }
+
+    const addr = "regen1xyz";
+    const events: string[] = [];
+
+    const a = withWalletLock(addr, async () => {
+      events.push("a:start");
+      await new Promise((r) => setTimeout(r, 30));
+      events.push("a:end");
+      return "a";
+    });
+    const b = withWalletLock(addr, async () => {
+      events.push("b:start");
+      await new Promise((r) => setTimeout(r, 10));
+      events.push("b:end");
+      return "b";
+    });
+
+    const [resA, resB] = await Promise.all([a, b]);
+    expect(resA).toBe("a");
+    expect(resB).toBe("b");
+    // Either a fully completes before b starts, or vice-versa — but never interleaved.
+    expect(events).toEqual(["a:start", "a:end", "b:start", "b:end"]);
+  });
+
+  it("does not serialize across different addresses", async () => {
+    const chains = new Map<string, Promise<unknown>>();
+    async function withWalletLock<T>(address: string, fn: () => Promise<T>): Promise<T> {
+      const prior = chains.get(address) ?? Promise.resolve();
+      let release: () => void;
+      const next = new Promise<void>((r) => { release = r; });
+      chains.set(address, next);
+      try {
+        await prior.catch(() => undefined);
+        return await fn();
+      } finally {
+        release!();
+        if (chains.get(address) === next) {
+          chains.delete(address);
+        }
+      }
+    }
+
+    const events: string[] = [];
+    const a = withWalletLock("addrA", async () => {
+      events.push("A:start");
+      await new Promise((r) => setTimeout(r, 20));
+      events.push("A:end");
+    });
+    const b = withWalletLock("addrB", async () => {
+      events.push("B:start");
+      await new Promise((r) => setTimeout(r, 5));
+      events.push("B:end");
+    });
+    await Promise.all([a, b]);
+    // B should overlap A (ends earlier) since they hold separate locks.
+    expect(events.indexOf("B:end")).toBeLessThan(events.indexOf("A:end"));
+  });
+});

--- a/src/server/api-routes.ts
+++ b/src/server/api-routes.ts
@@ -476,6 +476,20 @@ export function createApiRoutes(
       return;
     }
 
+    // Idempotency-Key support (audit C2). Standard header per Stripe/IETF
+    // draft-ietf-httpapi-idempotency-key-header. Body field is also accepted
+    // for clients that can't set headers easily.
+    const headerKey = req.headers["idempotency-key"];
+    const rawKey =
+      (Array.isArray(headerKey) ? headerKey[0] : headerKey) ??
+      (req.body && typeof req.body.idempotency_key === "string" ? req.body.idempotency_key : undefined);
+    const idempotencyKey = typeof rawKey === "string" && rawKey.trim().length > 0 ? rawKey.trim() : undefined;
+
+    if (idempotencyKey && idempotencyKey.length > 255) {
+      apiError(res, 400, "INVALID_REQUEST", "idempotency_key must be 255 characters or fewer");
+      return;
+    }
+
     try {
       const result = await executeRetirement({
         creditClass: credit_class,
@@ -483,6 +497,8 @@ export function createApiRoutes(
         beneficiaryName: beneficiary_name,
         jurisdiction,
         reason,
+        idempotencyKey,
+        db,
       });
 
       if (result.status === "success") {

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -287,6 +287,18 @@ export function getDb(dbPath = "data/regen-compute.db"): Database.Database {
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
+    -- Idempotency cache for on-chain retirement calls. When a caller passes
+    -- the same Idempotency-Key twice (e.g. retried HTTP request), the second
+    -- call returns the cached result without re-broadcasting to the chain.
+    CREATE TABLE IF NOT EXISTS retirement_idempotency_keys (
+      idempotency_key TEXT PRIMARY KEY,
+      tx_hash TEXT,
+      result_json TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_retirement_idempotency_created
+      ON retirement_idempotency_keys(created_at);
+
     CREATE TABLE IF NOT EXISTS crypto_payments (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       chain TEXT NOT NULL,
@@ -1607,6 +1619,64 @@ export function isEventProcessed(db: Database.Database, eventId: string): boolea
 
 export function markEventProcessed(db: Database.Database, eventId: string, eventType: string): void {
   db.prepare("INSERT OR IGNORE INTO processed_webhook_events (event_id, event_type) VALUES (?, ?)").run(eventId, eventType);
+}
+
+// --- Retirement idempotency ---
+
+const IDEMPOTENCY_TTL_HOURS = 24;
+
+/**
+ * Look up a previously-cached retirement result for an idempotency key.
+ * Entries older than IDEMPOTENCY_TTL_HOURS are ignored (and lazily purged).
+ * Returns the cached JSON-decoded result, or null if not present / expired.
+ */
+export function getCachedRetirementResult(
+  db: Database.Database,
+  idempotencyKey: string,
+): { result: unknown; txHash: string | null } | null {
+  const row = db.prepare(
+    `SELECT tx_hash, result_json
+     FROM retirement_idempotency_keys
+     WHERE idempotency_key = ?
+       AND created_at > datetime('now', ?)`
+  ).get(idempotencyKey, `-${IDEMPOTENCY_TTL_HOURS} hours`) as
+    | { tx_hash: string | null; result_json: string }
+    | undefined;
+  if (!row) return null;
+  try {
+    return { result: JSON.parse(row.result_json), txHash: row.tx_hash };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Store a completed retirement result against an idempotency key. INSERT OR
+ * IGNORE so that a racing duplicate broadcast (which the wallet mutex should
+ * prevent, but defensively) cannot clobber the first result.
+ */
+export function cacheRetirementResult(
+  db: Database.Database,
+  idempotencyKey: string,
+  txHash: string | null,
+  result: unknown,
+): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO retirement_idempotency_keys
+       (idempotency_key, tx_hash, result_json)
+     VALUES (?, ?, ?)`
+  ).run(idempotencyKey, txHash, JSON.stringify(result));
+}
+
+/**
+ * Best-effort cleanup of expired idempotency entries. Safe to call periodically.
+ */
+export function pruneExpiredIdempotencyKeys(db: Database.Database): number {
+  const result = db.prepare(
+    `DELETE FROM retirement_idempotency_keys
+     WHERE created_at <= datetime('now', ?)`
+  ).run(`-${IDEMPOTENCY_TTL_HOURS} hours`);
+  return result.changes;
 }
 
 // --- Organization helpers (#55) ---

--- a/src/server/openapi.json
+++ b/src/server/openapi.json
@@ -29,7 +29,19 @@
       "post": {
         "operationId": "retireCredits",
         "summary": "Retire ecocredits on Regen Network",
-        "description": "Execute an on-chain credit retirement. When a wallet is configured, credits are purchased and retired via MsgBuyDirect. Otherwise, returns a marketplace link for manual purchase.",
+        "description": "Execute an on-chain credit retirement. When a wallet is configured, credits are purchased and retired via MsgBuyDirect. Otherwise, returns a marketplace link for manual purchase.\n\nIdempotency: pass an `Idempotency-Key` header (or `idempotency_key` body field) to make the call safely retriable. Repeated requests with the same key within 24 hours return the original result without re-broadcasting on chain.",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Optional client-supplied key (max 255 chars). Repeated calls with the same key return the cached result without re-broadcasting.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 255
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -479,6 +491,11 @@
           "reason": {
             "type": "string",
             "description": "Reason for retirement"
+          },
+          "idempotency_key": {
+            "type": "string",
+            "description": "Optional idempotency key (alternative to the Idempotency-Key header). Repeated calls with the same key within 24 hours return the cached result.",
+            "maxLength": 255
           }
         }
       },

--- a/src/services/retirement.ts
+++ b/src/services/retirement.ts
@@ -13,6 +13,8 @@ import { CryptoPaymentProvider } from "./payment/crypto.js";
 import { StripePaymentProvider } from "./payment/stripe-stub.js";
 import type { PaymentProvider } from "./payment/types.js";
 import { buildRetirementReason } from "./retirement-reason.js";
+import { cacheRetirementResult, getCachedRetirementResult } from "../server/db.js";
+import type Database from "better-sqlite3";
 
 export interface RetirementParams {
   creditClass?: string;
@@ -20,6 +22,17 @@ export interface RetirementParams {
   beneficiaryName?: string;
   jurisdiction?: string;
   reason?: string;
+  /**
+   * Optional idempotency key. When provided alongside `db`, repeated calls
+   * with the same key return the cached result without re-broadcasting on
+   * chain. See AUDIT.md C2.
+   */
+  idempotencyKey?: string;
+  /**
+   * SQLite handle used to read/write the idempotency cache. The MCP tool
+   * path doesn't have a DB and can omit it; the REST API supplies one.
+   */
+  db?: Database.Database;
 }
 
 export interface RetirementResult {
@@ -131,7 +144,17 @@ function fallback(message: string, params: RetirementParams): RetirementResult {
  * the MCP tool (markdown) and REST API (JSON) can consume.
  */
 export async function executeRetirement(params: RetirementParams): Promise<RetirementResult> {
-  const { creditClass, beneficiaryName } = params;
+  const { creditClass, beneficiaryName, idempotencyKey, db } = params;
+
+  // Idempotency check (audit C2). When the caller supplied an Idempotency-Key
+  // and we have a DB to consult, return any cached result rather than
+  // re-broadcasting on chain. The wallet-level mutex in signAndBroadcast
+  // backstops this for concurrent in-flight calls; the cache covers
+  // serial retries (e.g. an HTTP client that retried after a flaky network).
+  if (idempotencyKey && db) {
+    const cached = getCachedRetirementResult(db, idempotencyKey);
+    if (cached) return cached.result as RetirementResult;
+  }
 
   // Path A: No wallet -> marketplace link
   if (!isWalletConfigured()) {
@@ -305,6 +328,15 @@ export async function executeRetirement(params: RetirementParams): Promise<Retir
       const remaining = await checkPrepaidBalance();
       if (remaining) {
         result.remainingBalanceCents = remaining.balance_cents;
+      }
+    }
+
+    if (idempotencyKey && db) {
+      try {
+        cacheRetirementResult(db, idempotencyKey, result.txHash ?? null, result);
+      } catch (cacheErr) {
+        // Cache failure must not fail the retirement — the on-chain side already succeeded.
+        console.error("Failed to cache idempotent retirement result:", cacheErr);
       }
     }
 

--- a/src/services/wallet.ts
+++ b/src/services/wallet.ts
@@ -69,9 +69,33 @@ export async function getBalance(denom: string): Promise<bigint> {
   return BigInt(coin.amount);
 }
 
+/**
+ * Per-address mutex chain. CosmJS auto-sequence handling races when two
+ * signAndBroadcast calls overlap (both fetch the same sequence number,
+ * one tx fails). The wallet is also a singleton in this process, so a
+ * single chained-promise per address is enough.
+ */
+const _broadcastChains = new Map<string, Promise<unknown>>();
+
+async function withWalletLock<T>(address: string, fn: () => Promise<T>): Promise<T> {
+  const prior = _broadcastChains.get(address) ?? Promise.resolve();
+  let release: () => void;
+  const next = new Promise<void>((r) => { release = r; });
+  _broadcastChains.set(address, next);
+  try {
+    await prior.catch(() => undefined);
+    return await fn();
+  } finally {
+    release!();
+    if (_broadcastChains.get(address) === next) {
+      _broadcastChains.delete(address);
+    }
+  }
+}
+
 export async function signAndBroadcast(
   messages: EncodeObject[]
 ): Promise<DeliverTxResponse> {
   const { address, client } = await initWallet();
-  return client.signAndBroadcast(address, messages, "auto");
+  return withWalletLock(address, () => client.signAndBroadcast(address, messages, "auto"));
 }


### PR DESCRIPTION
## Summary

Closes the audit's C2-MEDIUM finding: `executeRetirement()` had no protection against double-execution. If called twice in quick succession, both calls passed `checkPrepaidBalance()`, both passed `authorizePayment()`, and both called `signAndBroadcast()` — two transactions on chain, prepaid balance debited twice.

## What this PR does

Two layers of protection:

### 1. Wallet-level mutex (`src/services/wallet.ts`)

`signAndBroadcast()` now serializes through a per-address chained promise. CosmJS auto-sequence handling races when two broadcasts overlap (both fetch the same sequence number, one tx fails) — the mutex prevents that, and as a side effect prevents two broadcasts from the same wallet hitting the chain simultaneously.

### 2. `Idempotency-Key` cache (`src/services/retirement.ts` + `db.ts`)

- New `retirement_idempotency_keys` table — keyed by client-supplied opaque key, 24h TTL.
- REST `/api/v1/retire` reads the standard `Idempotency-Key` header (or `idempotency_key` body field as fallback for clients that can't easily set headers).
- `executeRetirement` checks the cache before any work and returns the cached result on hit.
- Successful results persist with `INSERT OR IGNORE` so a racing duplicate cannot clobber the first.
- `getCachedRetirementResult` tolerates malformed JSON; cache write failures are logged but never fail the retirement (on-chain side already succeeded).

The MCP tool path is unaffected — it doesn't pass a key or db, and runs through the same code path it always has. New behavior is purely opt-in via the REST API.

OpenAPI spec updated to document the new header + body field.

## Files changed

- `src/services/wallet.ts` — per-address mutex around `signAndBroadcast`
- `src/server/db.ts` — `retirement_idempotency_keys` table + `getCachedRetirementResult` / `cacheRetirementResult` / `pruneExpiredIdempotencyKeys`
- `src/services/retirement.ts` — `idempotencyKey` and `db` added to `RetirementParams`; cache check at entry, cache write after success
- `src/server/api-routes.ts` — read `Idempotency-Key` header / `idempotency_key` body field on `/api/v1/retire`
- `src/server/openapi.json` — document the new parameter
- `src/__tests__/retirement-idempotency.test.ts` — 8 new tests

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 57/57 passing (49 prior + 8 new)
- [x] `npm run build` — clean
- [ ] Reviewer: check that 24h TTL is the right value (Stripe's standard is 24h; tunable via the SQL constant if not)
- [ ] Reviewer: confirm mutex placement inside `signAndBroadcast` doesn't conflict with the existing `_subscriberLocks` in `routes.ts` (it shouldn't — that lock is per-subscriber, this is per-wallet, and they nest cleanly)

## Why narrow

Deliberately scoped to the audit finding. Not included here:
- Auto-pruning of expired idempotency rows on a schedule (helper exists; wiring to a cron is a separate concern).
- Idempotency on the MCP tool path. Each LLM tool call should produce a distinct retirement, so auto-deduping would be wrong without an explicit mechanism for the LLM to opt in.

Refs: `AUDIT.md` C2-MEDIUM

🤖 Generated with [Claude Code](https://claude.com/claude-code)