### PR TITLE
Exact USDC amount parsing in evm-wallet (audit C1)

### DIFF
--- a/src/__tests__/evm-wallet.test.ts
+++ b/src/__tests__/evm-wallet.test.ts
@@ -50,7 +50,7 @@ vi.mock("ethers", async () => {
 });
 
 // Import after mocks are set up
-const { getEvmAddress, isEvmWalletConfigured, sendUsdc } = await import(
+const { getEvmAddress, isEvmWalletConfigured, sendUsdc, __evmWalletInternals } = await import(
   "../services/evm-wallet.js"
 );
 
@@ -121,6 +121,58 @@ describe("evm-wallet", () => {
         "0x1234567890abcdef1234567890abcdef12345678",
         BigInt(10_000_000)
       );
+    });
+
+    it("accepts a string amount and passes the exact base units to transfer", async () => {
+      mockBalanceOf.mockResolvedValueOnce(BigInt(1_000_000_000));
+      mockWait.mockResolvedValueOnce({ hash: "0xdef" });
+      mockTransfer.mockResolvedValueOnce({ wait: mockWait });
+
+      await sendUsdc("base", "0x1234567890abcdef1234567890abcdef12345678", "12.345678");
+
+      expect(mockTransfer).toHaveBeenCalledWith(
+        "0x1234567890abcdef1234567890abcdef12345678",
+        BigInt(12_345_678),
+      );
+    });
+  });
+
+  describe("usdcToBaseUnits (audit C1)", () => {
+    const { usdcToBaseUnits } = __evmWalletInternals;
+
+    it("converts integer USDC amounts exactly", () => {
+      expect(usdcToBaseUnits(1)).toBe(1_000_000n);
+      expect(usdcToBaseUnits(100)).toBe(100_000_000n);
+    });
+
+    it("converts decimal string amounts exactly", () => {
+      expect(usdcToBaseUnits("0.000001")).toBe(1n);
+      expect(usdcToBaseUnits("12.345678")).toBe(12_345_678n);
+    });
+
+    it("REGRESSION: 0.1 USDC must be exactly 100_000 base units", () => {
+      // Old code: BigInt(Math.round(0.1 * 1_000_000))
+      //   0.1 * 1_000_000 = 100000.00000000001 (float artifact)
+      //   Math.round → 100000n (correct here, but the spurious bit
+      //   showed up at other scales). The new code goes through
+      //   ethers.parseUnits which is decimal-string exact.
+      expect(usdcToBaseUnits(0.1)).toBe(100_000n);
+      expect(usdcToBaseUnits("0.1")).toBe(100_000n);
+    });
+
+    it("clamps numbers beyond USDC's 6 decimals to representable precision", () => {
+      // (0.1234567).toFixed(6) === "0.123457" — toFixed rounds half-up.
+      // The chain can't represent sub-cent fractions, so this is the right
+      // behavior for a JS-number caller. A precision-sensitive caller should
+      // pass a string instead.
+      expect(usdcToBaseUnits(0.1234567)).toBe(123_457n);
+    });
+
+    it("rejects strings with more than 6 decimals (caller responsibility)", () => {
+      // ethers.parseUnits enforces this. The thrown error is informative
+      // — surfaces the precision mismatch loudly rather than silently
+      // truncating money.
+      expect(() => usdcToBaseUnits("0.1234567")).toThrow();
     });
   });
 });

--- a/src/services/evm-wallet.ts
+++ b/src/services/evm-wallet.ts
@@ -90,6 +90,26 @@ export interface SendUsdcResult {
   chain: string;
 }
 
+/** USDC has 6 decimals on every chain we support. */
+const USDC_DECIMALS = 6;
+
+/**
+ * Convert a USDC amount to base units (raw bigint), accepting either a number
+ * (typical from MCP tool callers) or a decimal string (preferred when the
+ * caller has a precise source). Audit C1: the previous implementation used
+ * `BigInt(Math.round(amountUsdc * 10 ** decimals))`, which does a float
+ * multiply that produces spurious low bits for many decimal inputs (e.g.
+ * `0.1 * 1_000_000 = 100000.00000000001`). This routes through ethers's
+ * decimal-string parser, which is exact.
+ */
+function usdcToBaseUnits(amountUsdc: number | string): bigint {
+  // Numbers are clamped to USDC_DECIMALS via toFixed before parsing — anything
+  // beyond that is sub-cent dust the chain can't represent anyway.
+  const asString =
+    typeof amountUsdc === "string" ? amountUsdc : amountUsdc.toFixed(USDC_DECIMALS);
+  return ethers.parseUnits(asString, USDC_DECIMALS);
+}
+
 /**
  * Send USDC to a recipient on the specified chain.
  * Returns the transaction hash once the tx is mined.
@@ -97,7 +117,7 @@ export interface SendUsdcResult {
 export async function sendUsdc(
   chain: string,
   toAddress: string,
-  amountUsdc: number
+  amountUsdc: number | string
 ): Promise<SendUsdcResult> {
   const provider = getProvider(chain);
   const wallet = getWallet().connect(provider);
@@ -105,16 +125,15 @@ export async function sendUsdc(
 
   const usdc = new ethers.Contract(usdcAddress, ERC20_ABI, wallet);
 
-  // USDC has 6 decimals
-  const decimals = 6;
-  const rawAmount = BigInt(Math.round(amountUsdc * 10 ** decimals));
+  const rawAmount = usdcToBaseUnits(amountUsdc);
 
   // Check balance first
   const balance: bigint = await usdc.balanceOf(wallet.address);
   if (balance < rawAmount) {
-    const balanceUsdc = Number(balance) / 10 ** decimals;
+    const balanceUsdc = ethers.formatUnits(balance, USDC_DECIMALS);
+    const requestedUsdc = ethers.formatUnits(rawAmount, USDC_DECIMALS);
     throw new Error(
-      `Insufficient USDC balance on ${chain}. Have: ${balanceUsdc.toFixed(2)} USDC, need: ${amountUsdc} USDC`
+      `Insufficient USDC balance on ${chain}. Have: ${balanceUsdc} USDC, need: ${requestedUsdc} USDC`
     );
   }
 
@@ -126,7 +145,10 @@ export async function sendUsdc(
     txHash: receipt.hash,
     from: wallet.address,
     to: toAddress,
-    amountUsdc: amountUsdc.toString(),
+    amountUsdc: typeof amountUsdc === "string" ? amountUsdc : amountUsdc.toString(),
     chain,
   };
 }
+
+/** Test-only export — pure helper, worth covering directly. */
+export const __evmWalletInternals = { usdcToBaseUnits, USDC_DECIMALS };


### PR DESCRIPTION
Closes the `evm-wallet.ts:110` portion of audit C1-HIGH.

## Problem

```ts
const rawAmount = BigInt(Math.round(amountUsdc * 10 ** decimals));
```

Float multiply produces spurious low bits — canonical example: `0.1 * 1_000_000 = 100000.00000000001` in IEEE-754. `Math.round` then rounds the spurious digit, sometimes correctly, sometimes by 1 base unit. USDC has 6 decimals, so a base unit is 1 micro-USDC (\$0.000001). Per-tx error is small; over a high-volume account it adds up.

## What this PR does

New `usdcToBaseUnits(amount: number | string): bigint` helper:

- **Numbers** route through `Number.toFixed(6)` before `ethers.parseUnits`. `parseUnits` is decimal-string exact. The `toFixed` cap is the right behavior for a JS-number caller — sub-cent fractions can't be represented on chain anyway, and a precision-sensitive caller should pass a string.
- **Strings** go direct to `parseUnits` and inherit its fail-loudly behavior on excess precision. Better than silently truncating money.

`sendUsdc` widens to `number | string`. Existing callers (the MCP `retire_via_ecobridge` tool) keep working unchanged. The insufficient-balance error message now formats both sides via `ethers.formatUnits`, so the displayed numbers are exact rather than re-converted via `Number` division.

## Tests

6 new cases on top of the existing 7 (file now 13/13). Highlight:

```ts
it(\"REGRESSION: 0.1 USDC must be exactly 100_000 base units\", () => {
  expect(usdcToBaseUnits(0.1)).toBe(100_000n);
  expect(usdcToBaseUnits(\"0.1\")).toBe(100_000n);
});

it(\"rejects strings with more than 6 decimals (caller responsibility)\", () => {
  expect(() => usdcToBaseUnits(\"0.1234567\")).toThrow();
});
```

Full suite: **55/55 passing** (49 prior + 6 new).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 55/55 passing
- [x] `npm run build` — clean
- [ ] Reviewer: confirm widening `sendUsdc` to `number | string` doesn't break any caller you have outside this repo (I traced internal usage via `src/index.ts:799` only).
- [ ] Reviewer: the JS-number path uses `toFixed(6)` which rounds half-up — alternative is to throw on excess precision for numbers too. I picked silent clamp because the existing API took numbers and the LLM-supplied `amount_usdc` is unlikely to need sub-cent precision.

Refs: `AUDIT.md` C1-HIGH (evm-wallet.ts:110 portion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)