### PR TITLE
Structured JSON-LD reason on monthly pool retirements (#101 Phase A)

### DIFF
--- a/src/__tests__/pool.test.ts
+++ b/src/__tests__/pool.test.ts
@@ -284,6 +284,28 @@ describe("Pool Service", () => {
       expect(result.carbon.txHash).toBe("AABB1122,AABB1122");
     });
 
+    it("uses structured JSON-LD retirement reason on chain (#101 Phase A)", async () => {
+      addTestSubscribers(3, 500);
+
+      await executePoolRun({ dryRun: false });
+
+      const firstCall = vi.mocked(signAndBroadcast).mock.calls[0];
+      expect(firstCall).toBeDefined();
+      const buyMsg = firstCall![0][0] as {
+        value: { orders: Array<{ retirementReason: string }> };
+      };
+      const reasonStr = buyMsg.value.orders[0].retirementReason;
+
+      // Should parse as JSON, not be a plain English string.
+      const parsed = JSON.parse(reasonStr);
+      expect(parsed["@context"]).toBe("https://schema.regen.network/v1");
+      expect(parsed.type).toBe("ComputeFootprintRetirement");
+      expect(parsed.tool).toBe("regen-compute");
+      expect(parsed.source).toBe("subscription");
+      expect(parsed.period).toMatch(/^\d{4}-\d{2}$/);
+      expect(parsed.note).toMatch(/\d+ subscribers?/);
+    });
+
     it("records per-subscriber fractional attributions", async () => {
       // 2 subscribers with different amounts
       const user1 = db.prepare("INSERT INTO users (api_key, email) VALUES (?, ?)").run("rfa_a", "a@test.com");

--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -34,6 +34,7 @@ import {
 } from "../server/db.js";
 import { sendMonthlyEmails } from "./email.js";
 import { executeBurn, type BurnResult, formatBurnResult } from "./burn.js";
+import { buildRetirementReason } from "./retirement-reason.js";
 
 export interface PoolRunResult {
   poolRunId: number;
@@ -375,6 +376,16 @@ export async function executePoolRun(options: {
         continue;
       }
 
+      // #101 Phase A: structured JSON-LD reason so the on-chain retirement
+      // carries semantic context (period, source, methodology version).
+      // Backward-compatible — older indexers still see a valid string.
+      const period = poolRun.run_date.slice(0, 7); // YYYY-MM
+      const poolRetirementReason = buildRetirementReason({
+        note: `Monthly pool retirement covering ${subscribers.length} subscriber${subscribers.length === 1 ? "" : "s"}`,
+        period,
+        source: "subscription",
+      });
+
       // Build and broadcast MsgBuyDirect
       const buyOrders = selectedOrders.map((s) => ({
         sellOrderId: BigInt(s.order.id),
@@ -385,7 +396,7 @@ export async function executePoolRun(options: {
         },
         disableAutoRetire: false,
         retirementJurisdiction: config.defaultJurisdiction,
-        retirementReason: `Monthly pool retirement — Regen Compute`,
+        retirementReason: poolRetirementReason,
       }));
 
       const msg = {


### PR DESCRIPTION
Closes the pool-path gap in #101 Phase A.

## Problem

`buildRetirementReason` (shipped in commit `d3c4e80`) is wired into:

- `retirement.ts` (MCP tool path) ✅
- `retire-subscriber.ts` (per-subscriber retirements) ✅
- `pool.ts` (monthly pool runs) ❌ — still uses the plain string `\"Monthly pool retirement — Regen Compute\"`

Pool runs are where the on-chain volume happens — every subscriber's monthly contribution flows through `MsgBuyDirect` there. The plain-text reason gives indexers, the KOI semantic layer, and the eventual CLAMS CosmWasm contract no machine-readable context.

## What this PR does

`pool.ts` now calls `buildRetirementReason(...)` with:

- `source: \"subscription\"`
- `period`: \"YYYY-MM\" derived from `poolRun.run_date`
- `note`: human-readable \"covering N subscriber(s)\" descriptor

Backward-compatible: older consumers see a valid string (the JSON serialization).

## Test

```ts
it(\"uses structured JSON-LD retirement reason on chain (#101 Phase A)\", async () => {
  await executePoolRun({ dryRun: false });
  const buyMsg = vi.mocked(signAndBroadcast).mock.calls[0][0][0];
  const parsed = JSON.parse(buyMsg.value.orders[0].retirementReason);
  expect(parsed[\"@context\"]).toBe(\"https://schema.regen.network/v1\");
  expect(parsed.type).toBe(\"ComputeFootprintRetirement\");
  expect(parsed.source).toBe(\"subscription\");
  expect(parsed.period).toMatch(/^\\d{4}-\\d{2}$/);
  expect(parsed.note).toMatch(/\\d+ subscribers?/);
});
```

Full suite: **50/50 passing** (49 prior + 1 new).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 50/50 passing
- [x] `npm run build` — clean
- [ ] Reviewer (or @glandua): confirm `source: \"subscription\"` is the intended literal for ADR-004 / CLAMS alignment. The other call sites use `\"mcp_tool\"` or `\"subscription\"`; pool runs are subscription-driven so I went with the latter.

## Out of scope

- The `subscriberId` field on `StructuredReasonOptions` is declared in `retirement-reason.ts` but `buildRetirementReason()` doesn't actually serialize it. Worth fixing in its own micro-PR if you want — pool runs cover many subscribers so it doesn't apply here, but it does for `retire-subscriber.ts`.
- Phase B (formalizing `COMPUTE_FOOTPRINT` as an ADR-004 ClaimType) — that work lives in `regen-data-standards`, not here.

Refs: #101 Phase A

🤖 Generated with [Claude Code](https://claude.com/claude-code)